### PR TITLE
Support for project.version property reading the original BOM

### DIFF
--- a/maven-plugin/src/main/java/io/quarkus/bom/decomposer/maven/GeneratePlatformBomMojo.java
+++ b/maven-plugin/src/main/java/io/quarkus/bom/decomposer/maven/GeneratePlatformBomMojo.java
@@ -36,6 +36,7 @@ import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.impl.RemoteRepositoryManager;
 import org.eclipse.aether.repository.RemoteRepository;
 
 @Mojo(name = "generate-platform-bom", defaultPhase = LifecyclePhase.INITIALIZE, requiresDependencyCollection = ResolutionScope.NONE)
@@ -43,6 +44,9 @@ public class GeneratePlatformBomMojo extends AbstractMojo {
 
     @Component
     private RepositorySystem repoSystem;
+
+    @Component
+    private RemoteRepositoryManager remoteRepoManager;
 
     @Parameter(defaultValue = "${project.remoteProjectRepositories}", readonly = true, required = true)
     private List<RemoteRepository> repos;
@@ -180,6 +184,7 @@ public class GeneratePlatformBomMojo extends AbstractMojo {
                     .setRepositorySystem(repoSystem)
                     .setRepositorySystemSession(repoSession)
                     .setRemoteRepositories(repos)
+                    .setRemoteRepositoryManager(remoteRepoManager)
                     .build() : artifactResolver;
         } catch (BootstrapMavenException e) {
             throw new MojoExecutionException("Failed to initialize Maven artifact resolver", e);

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <maven-plugin-annotations.version>3.6.0</maven-plugin-annotations.version>
     <maven-source-plugin.version>3.2.0</maven-source-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
-    <quarkus.version>1.8.2.Final</quarkus.version>
+    <quarkus.version>1.9.0.Final</quarkus.version>
   </properties>
   <modules>
     <module>bom-decomposer</module>


### PR DESCRIPTION
When the original platform BOM is read, `${project.version}` property which may appear as a value in some dependencies (which is not currently the case but will probably be in the future) will not be replaced. This PR fixes that.
The dependency on Quarkus core is upgraded to 1.9.0.Final.