### PR TITLE
#72 use version from testCatalogArtifact in GeneratePlatformProjectMojo

### DIFF
--- a/maven-plugin/src/main/java/io/quarkus/bom/decomposer/maven/platformgen/GeneratePlatformProjectMojo.java
+++ b/maven-plugin/src/main/java/io/quarkus/bom/decomposer/maven/platformgen/GeneratePlatformProjectMojo.java
@@ -665,7 +665,7 @@ public class GeneratePlatformProjectMojo extends AbstractMojo {
                             + " contains an artifact with a missing artifactId " + testElement);
                 }
                 final ArtifactCoords testCoords = new ArtifactCoords(testGroupId, testArtifactId, null, "jar",
-                        member.originalBomCoords.getVersion());
+                        testCatalogArtifact.getVersion());
                 // add it unless it's overriden in the config
                 PlatformMemberTestConfig testConfig = testConfigs.get(testCoords);
                 if (testConfig == null) {


### PR DESCRIPTION
Use testCatalogArtifact version rather than originalBomCoords for testArtifacts from testCatalogArtifact itself.