### PR TITLE
Add property for skipping invoke-platform-project mojo

### DIFF
--- a/maven-plugin/src/main/java/io/quarkus/bom/decomposer/maven/platformgen/BuildPlatformProjectMojo.java
+++ b/maven-plugin/src/main/java/io/quarkus/bom/decomposer/maven/platformgen/BuildPlatformProjectMojo.java
@@ -34,7 +34,12 @@ public class BuildPlatformProjectMojo extends AbstractMojo {
     @Parameter(defaultValue = "${project}")
     protected MavenProject project;
 
-    @Parameter
+    /**
+     * Skip the execution of this mojo.
+     *
+     * @since 0.0.33
+     */
+    @Parameter(property = "quarkus.invoke-platform-project.skip", defaultValue = "false")
     boolean skip;
 
     @Component


### PR DESCRIPTION
This would be handy in a situation when there are known issues in some of the generated test projects.