### PR TITLE
Check whether the parent already includes the module name for the test module

### DIFF
--- a/maven-plugin/src/main/java/io/quarkus/bom/decomposer/maven/platformgen/GeneratePlatformProjectMojo.java
+++ b/maven-plugin/src/main/java/io/quarkus/bom/decomposer/maven/platformgen/GeneratePlatformProjectMojo.java
@@ -847,12 +847,24 @@ public class GeneratePlatformProjectMojo extends AbstractMojo {
             PlatformMemberTestConfig testConfig,
             Model parentPom)
             throws MojoExecutionException {
-        final String moduleName = testArtifact.getArtifactId();
+
+        final String moduleName;
+        if (parentPom.getModules().contains(testArtifact.getArtifactId())) {
+            String tmp = testArtifact.getArtifactId() + "-" + testArtifact.getVersion();
+            if (parentPom.getModules().contains(tmp)) {
+                throw new MojoExecutionException("The same test " + testArtifact + " appears to be added twice");
+            }
+            moduleName = tmp;
+            getLog().warn("Using " + moduleName + " as the module name for " + testArtifact + " since "
+                    + testArtifact.getArtifactId() + " module name already exists");
+        } else {
+            moduleName = testArtifact.getArtifactId();
+        }
+        parentPom.addModule(moduleName);
 
         final Model pom = newModel();
         pom.setArtifactId(moduleName);
         pom.setName(getNameBase(parentPom) + " " + moduleName);
-        parentPom.addModule(moduleName);
 
         final File pomXml = new File(new File(parentPom.getProjectDirectory(), moduleName), "pom.xml");
         pom.setPomFile(pomXml);


### PR DESCRIPTION
Fixes #81

With this change we are going to check whether the module name already exists in the parent POM before using for the test module and if it does warn and use `testArtifact.getArtifactId() + "-" + testArtifact.getVersion()` instead. If that module name also exists, throw an error.