### PR TITLE
Limit member descriptor generator to specific member extension artifactIds

### DIFF
--- a/maven-plugin/src/main/java/io/quarkus/bom/decomposer/maven/platformgen/GeneratePlatformProjectMojo.java
+++ b/maven-plugin/src/main/java/io/quarkus/bom/decomposer/maven/platformgen/GeneratePlatformProjectMojo.java
@@ -1485,6 +1485,22 @@ public class GeneratePlatformProjectMojo extends AbstractMojo {
             }
             final ObjectNode on = (ObjectNode) metadata;
             on.set(LAST_BOM_UPDATE, on.textNode("${" + MEMBER_LAST_BOM_UPDATE_PROP + "}"));
+
+            if (!member.config.getExtensionGroupIds().isEmpty()) {
+                final Xpp3Dom processGroupIds = new Xpp3Dom("processGroupIds");
+                config.addChild(processGroupIds);
+                for (String groupId : member.config.getExtensionGroupIds()) {
+                    final Xpp3Dom processGroupId = new Xpp3Dom("groupId");
+                    processGroupId.setValue(groupId);
+                    processGroupIds.addChild(processGroupId);
+                }
+            } else if (member.originalBomCoords() != null) {
+                final Xpp3Dom processGroupIds = new Xpp3Dom("processGroupIds");
+                config.addChild(processGroupIds);
+                final Xpp3Dom processGroupId = new Xpp3Dom("groupId");
+                processGroupId.setValue(member.originalBomCoords().getGroupId());
+                processGroupIds.addChild(processGroupId);
+            }
         }
 
         // METADATA OVERRIDES

--- a/maven-plugin/src/main/java/io/quarkus/bom/decomposer/maven/platformgen/PlatformMemberConfig.java
+++ b/maven-plugin/src/main/java/io/quarkus/bom/decomposer/maven/platformgen/PlatformMemberConfig.java
@@ -24,6 +24,8 @@ public class PlatformMemberConfig {
     private List<String> metadataOverrideFiles = new ArrayList<>(0);
     private List<String> metadataOverrideArtifacts = new ArrayList<>(0);
 
+    private List<String> extensionGroupIds = new ArrayList<>(0);
+
     void applyOverrides(PlatformMemberConfig overrides) {
         if (overrides.bom != null) {
             bom = overrides.bom;
@@ -77,6 +79,9 @@ public class PlatformMemberConfig {
         }
         if (!overrides.metadataOverrideArtifacts.isEmpty()) {
             metadataOverrideArtifacts.addAll(overrides.metadataOverrideArtifacts);
+        }
+        if (!overrides.extensionGroupIds.isEmpty()) {
+            extensionGroupIds.addAll(overrides.extensionGroupIds);
         }
     }
 
@@ -184,5 +189,19 @@ public class PlatformMemberConfig {
      */
     public List<String> getMetadataOverrideArtifacts() {
         return metadataOverrideArtifacts;
+    }
+
+    /**
+     * A list of artifact aroupIds of the member extensions which should be
+     * included in the generated member descriptor.
+     * 
+     * @return list of extension artifact groupIds
+     */
+    public List<String> getExtensionGroupIds() {
+        return extensionGroupIds;
+    }
+
+    public void setExtensionGroupIds(List<String> extensionGroupIds) {
+        this.extensionGroupIds = extensionGroupIds;
     }
 }


### PR DESCRIPTION
Defaulting to the member BOM groupId.