### PR TITLE
packageApplication option for tests

### DIFF
--- a/platform-bom/src/main/java/io/quarkus/bom/platform/PlatformMemberDefaultTestConfig.java
+++ b/platform-bom/src/main/java/io/quarkus/bom/platform/PlatformMemberDefaultTestConfig.java
@@ -24,6 +24,7 @@ public class PlatformMemberDefaultTestConfig {
     protected List<String> jvmExcludes = Collections.emptyList();
     protected List<String> nativeIncludes = Collections.emptyList();
     protected List<String> nativeExcludes = Collections.emptyList();
+    protected Boolean packageApplication;
 
     public PlatformMemberDefaultTestConfig() {
         super();
@@ -120,6 +121,9 @@ public class PlatformMemberDefaultTestConfig {
             } else {
                 nativeExcludes.addAll(overrides.jvmExcludes);
             }
+        }
+        if (overrides.packageApplication != null) {
+            packageApplication = overrides.packageApplication;
         }
     }
 
@@ -257,5 +261,13 @@ public class PlatformMemberDefaultTestConfig {
 
     public void setNativeExcludes(List<String> nativeExcludes) {
         this.nativeExcludes = nativeExcludes;
+    }
+
+    public void setPackageApplication(boolean packageApplication) {
+        this.packageApplication = packageApplication;
+    }
+
+    public boolean isPackageApplication() {
+        return packageApplication == null ? false : packageApplication;
     }
 }

--- a/platform-bom/src/main/java/io/quarkus/bom/platform/PlatformMemberTestConfig.java
+++ b/platform-bom/src/main/java/io/quarkus/bom/platform/PlatformMemberTestConfig.java
@@ -150,6 +150,9 @@ public class PlatformMemberTestConfig extends PlatformMemberDefaultTestConfig {
                 nativeIncludes.addAll(defaults.nativeIncludes);
             }
         }
+        if (packageApplication == null) {
+            packageApplication = defaults.packageApplication;
+        }
     }
 
     public static class Copy {


### PR DESCRIPTION
This option allows to configure the `io.quarkus:quarkus-maven-plugin` with the `build` goal for test modules that would package the app before running `QuarkusIntegrationTest`s.