### PR TITLE
Support for configuring member own groupIds

### DIFF
--- a/maven-plugin/src/main/java/io/quarkus/bom/decomposer/maven/platformgen/GeneratePlatformProjectMojo.java
+++ b/maven-plugin/src/main/java/io/quarkus/bom/decomposer/maven/platformgen/GeneratePlatformProjectMojo.java
@@ -2281,9 +2281,17 @@ public class GeneratePlatformProjectMojo extends AbstractMojo {
                 return config.getExtensionGroupIds();
             }
             if (originalBomCoords() != null) {
-                return Collections.singletonList(originalBomCoords().getGroupId());
+                return List.of(originalBomCoords().getGroupId());
             }
-            return Collections.emptyList();
+            return List.of();
+        }
+
+        @Override
+        public List<String> getOwnGroupIds() {
+            if (!config.getOwnGroupIds().isEmpty()) {
+                return config.getOwnGroupIds();
+            }
+            return getExtensionGroupIds();
         }
 
         @Override

--- a/platform-bom/src/main/java/io/quarkus/bom/platform/PlatformBomComposer.java
+++ b/platform-bom/src/main/java/io/quarkus/bom/platform/PlatformBomComposer.java
@@ -125,10 +125,10 @@ public class PlatformBomComposer implements DecomposedBomTransformer, Decomposed
                     .transform(originalBom);
             member.setOriginalDecomposedBom(originalBom);
 
-            if (!member.getExtensionGroupIds().isEmpty()) {
+            if (!member.getOwnGroupIds().isEmpty()) {
                 for (ProjectRelease r : originalBom.releases()) {
                     for (String groupId : r.groupIds()) {
-                        if (member.getExtensionGroupIds().contains(groupId)) {
+                        if (member.getOwnGroupIds().contains(groupId)) {
                             fixedReleases.computeIfAbsent(r.id().origin(), k -> new ArrayList<>()).add(r);
                             break;
                         }

--- a/platform-bom/src/main/java/io/quarkus/bom/platform/PlatformMember.java
+++ b/platform-bom/src/main/java/io/quarkus/bom/platform/PlatformMember.java
@@ -12,6 +12,8 @@ public interface PlatformMember {
 
     List<String> getExtensionGroupIds();
 
+    List<String> getOwnGroupIds();
+
     Artifact previousLastUpdatedBom();
 
     Artifact lastUpdatedBom();

--- a/platform-bom/src/main/java/io/quarkus/bom/platform/PlatformMemberConfig.java
+++ b/platform-bom/src/main/java/io/quarkus/bom/platform/PlatformMemberConfig.java
@@ -25,6 +25,7 @@ public class PlatformMemberConfig {
     private List<String> metadataOverrideArtifacts = new ArrayList<>(0);
 
     private List<String> extensionGroupIds = new ArrayList<>(0);
+    private List<String> ownGroupIds = new ArrayList<>(0);
 
     public void applyOverrides(PlatformMemberConfig overrides) {
         if (overrides.bom != null) {
@@ -84,6 +85,9 @@ public class PlatformMemberConfig {
         }
         if (!overrides.extensionGroupIds.isEmpty()) {
             extensionGroupIds.addAll(overrides.extensionGroupIds);
+        }
+        if (!overrides.ownGroupIds.isEmpty()) {
+            ownGroupIds.addAll(overrides.ownGroupIds);
         }
     }
 
@@ -205,7 +209,7 @@ public class PlatformMemberConfig {
     }
 
     /**
-     * A list of artifact aroupIds of the member extensions which should be
+     * A list of artifact groupIds of the member extensions which should be
      * included in the generated member descriptor.
      * 
      * @return list of extension artifact groupIds
@@ -216,5 +220,18 @@ public class PlatformMemberConfig {
 
     public void setExtensionGroupIds(List<String> extensionGroupIds) {
         this.extensionGroupIds = extensionGroupIds;
+    }
+
+    /**
+     * A list of artifact groupIds other members are not allowed to override
+     * 
+     * @return list of artifact groupIds other members are not allowed to override
+     */
+    public List<String> getOwnGroupIds() {
+        return ownGroupIds;
+    }
+
+    public void setOwnGroupIds(List<String> ownGroupIds) {
+        this.ownGroupIds = ownGroupIds;
     }
 }


### PR DESCRIPTION
If a member configures "own" groupIds, constraints with these groupIds can't be overridden by other members.