### PR TITLE
Keep dependencyManagement when flattening the Maven plugin's pom

### DIFF
--- a/maven-plugin/src/main/java/io/quarkus/bom/decomposer/maven/platformgen/GeneratePlatformProjectMojo.java
+++ b/maven-plugin/src/main/java/io/quarkus/bom/decomposer/maven/platformgen/GeneratePlatformProjectMojo.java
@@ -779,6 +779,7 @@ public class GeneratePlatformProjectMojo extends AbstractMojo {
 
             Xpp3Dom pomElements = new Xpp3Dom("pomElements");
             config.addChild(pomElements);
+            pomElements.addChild(textDomElement("dependencyManagement", "keep"));
             pomElements.addChild(textDomElement("repositories", "remove"));
             pomElements.addChild(textDomElement("build", "remove"));
 


### PR DESCRIPTION
To make sure the platform BOM is enforced on the transitive dependencies of the plugin.