### PR TITLE
Allow DependencySpecs with a custom scope

### DIFF
--- a/platform-bom/src/main/java/io/quarkus/bom/platform/DependencyManagementConfig.java
+++ b/platform-bom/src/main/java/io/quarkus/bom/platform/DependencyManagementConfig.java
@@ -63,8 +63,12 @@ public class DependencyManagementConfig {
                 final ArtifactKey key = ArtifactKey.fromString(e);
                 exclusions.add(new Exclusion(key.getGroupId(), key.getArtifactId(), key.getClassifier(), key.getType()));
             }
+            String scope = dep.getScope();
+            if (scope == null || scope.isEmpty()) {
+                scope = "compile";
+            }
             result.add(new Dependency(new DefaultArtifact(coords.getGroupId(),
-                    coords.getArtifactId(), coords.getClassifier(), coords.getType(), coords.getVersion()), "compile", null,
+                    coords.getArtifactId(), coords.getClassifier(), coords.getType(), coords.getVersion()), scope, null,
                     exclusions));
         }
         return result;

--- a/platform-bom/src/main/java/io/quarkus/bom/platform/DependencySpec.java
+++ b/platform-bom/src/main/java/io/quarkus/bom/platform/DependencySpec.java
@@ -6,6 +6,7 @@ import java.util.List;
 public class DependencySpec {
 
     private String artifact;
+    private String scope;
     private List<String> exclusions = Collections.emptyList();
 
     public String getArtifact() {
@@ -14,6 +15,14 @@ public class DependencySpec {
 
     public void setArtifact(String artifact) {
         this.artifact = artifact;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+
+    public void setScope(String scope) {
+        this.scope = scope;
     }
 
     public List<String> getExclusions() {
@@ -26,13 +35,19 @@ public class DependencySpec {
 
     @Override
     public String toString() {
-        if (exclusions.isEmpty()) {
+        if (exclusions.isEmpty() && (scope == null || scope.isEmpty())) {
             return artifact;
         }
         final StringBuilder s = new StringBuilder();
-        s.append(artifact).append(" exclusions: ").append(exclusions.get(0));
-        for (int i = 1; i < exclusions.size(); ++i) {
-            s.append(',').append(exclusions.get(i));
+        s.append(artifact);
+        if (scope != null && !scope.isEmpty()) {
+            s.append('(').append(scope).append(')');
+        }
+        if (!exclusions.isEmpty()) {
+            s.append(" exclusions: ").append(exclusions.get(0));
+            for (int i = 1; i < exclusions.size(); ++i) {
+                s.append(',').append(exclusions.get(i));
+            }
         }
         return s.toString();
     }


### PR DESCRIPTION
@aloubyansky I'd need this to be able to force using the newest Mandrel in the Platform without rebuilding Quarkus core. 
Something like 

```
                  <dependencySpec>
                    <artifact>org.graalvm.nativeimage:svm:${graalvm.version}</artifact>
                    <scope>provided</scope>
                    <exclusions>
                        <exclusion>*:*</exclusion>
                    </exclusions>
                  </dependencySpec>
```

See around here: https://gitlab.cee.redhat.com/ppalaga/quarkus-platform/-/commit/c38288bcf292fd31773fb57dcc13fe103a5179c4?page=14#442292b8a7efeabbe4cc176709b833b1792140ec_69_73

I'd need a release if this change looks good.