### PR TITLE
Domino: Added comma-separated multi input functionality to --root-artifacts command line flag

### DIFF
--- a/domino/app/src/main/java/io/quarkus/domino/cli/BaseDepsToBuildCommand.java
+++ b/domino/app/src/main/java/io/quarkus/domino/cli/BaseDepsToBuildCommand.java
@@ -30,7 +30,7 @@ public abstract class BaseDepsToBuildCommand implements Callable<Integer> {
     public Boolean includeNonManaged;
 
     @CommandLine.Option(names = {
-            "--root-artifacts" }, description = "Root artifacts whose dependencies should be built from source")
+            "--root-artifacts" }, description = "Root artifacts whose dependencies should be built from source", split = ",")
     public Collection<String> rootArtifacts = List.of();
 
     @CommandLine.Option(names = {


### PR DESCRIPTION
In order to be able to provide a comma-separated artifacts list to the --root-artifacts flag (e.g. --root-artifacts=a1,a2,a3), I added split="," to the annotation associated with said flag.

Changed from what we currently have (6.1.1 from doc below), to use a comma split (6.2 from doc below)
https://picocli.info/#_multiple_values
