### PR TITLE
Add default main SBOM component in case product info is not configured

### DIFF
--- a/domino/api/src/main/java/io/quarkus/domino/manifest/PurgingDependencyTreeVisitor.java
+++ b/domino/api/src/main/java/io/quarkus/domino/manifest/PurgingDependencyTreeVisitor.java
@@ -251,23 +251,7 @@ public class PurgingDependencyTreeVisitor implements DependencyTreeVisitor {
 
         @Override
         public PackageURL getPurl() {
-            if (purl == null) {
-                final TreeMap<String, String> qualifiers = new TreeMap<>();
-                qualifiers.put("type", coords.getType());
-                if (!coords.getClassifier().isEmpty()) {
-                    qualifiers.put("classifier", coords.getClassifier());
-                }
-                try {
-                    purl = new PackageURL(PackageURL.StandardTypes.MAVEN,
-                            coords.getGroupId(),
-                            coords.getArtifactId(),
-                            coords.getVersion(),
-                            qualifiers, null);
-                } catch (MalformedPackageURLException e) {
-                    throw new RuntimeException("Failed to generate Purl for " + coords.toCompactCoords(), e);
-                }
-            }
-            return purl;
+            return purl == null ? purl = PurgingDependencyTreeVisitor.getPurl(coords) : purl;
         }
 
         @Override
@@ -299,6 +283,23 @@ public class PurgingDependencyTreeVisitor implements DependencyTreeVisitor {
             }
             sb.append(coords.getVersion()).append('#').append(processedVariations);
             bomRef = sb.toString();
+        }
+    }
+
+    static PackageURL getPurl(ArtifactCoords coords) {
+        final TreeMap<String, String> qualifiers = new TreeMap<>();
+        qualifiers.put("type", coords.getType());
+        if (!coords.getClassifier().isEmpty()) {
+            qualifiers.put("classifier", coords.getClassifier());
+        }
+        try {
+            return new PackageURL(PackageURL.StandardTypes.MAVEN,
+                    coords.getGroupId(),
+                    coords.getArtifactId(),
+                    coords.getVersion(),
+                    qualifiers, null);
+        } catch (MalformedPackageURLException e) {
+            throw new RuntimeException("Failed to generate Purl for " + coords.toCompactCoords(), e);
         }
     }
 }

--- a/domino/api/src/main/java/io/quarkus/domino/manifest/SbomGeneratingDependencyVisitor.java
+++ b/domino/api/src/main/java/io/quarkus/domino/manifest/SbomGeneratingDependencyVisitor.java
@@ -1,24 +1,41 @@
 package io.quarkus.domino.manifest;
 
 import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
+import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
 import io.quarkus.domino.DependencyTreeVisitor;
 import io.quarkus.domino.ProductInfo;
+import io.quarkus.domino.ProjectDependencyConfig;
+import io.quarkus.maven.dependency.ArtifactCoords;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import org.cyclonedx.model.Bom;
+import org.cyclonedx.model.Component;
 
 public class SbomGeneratingDependencyVisitor implements DependencyTreeVisitor {
 
     private static final String DOMINO_VALIDATE_SBOM_TREES = "domino.validate.sbom.trees";
 
     private final SbomGenerator.Builder sbomGenerator;
-    private final PurgingDependencyTreeVisitor treeBuilder;
+    private final PurgingDependencyTreeVisitor treeBuilder = new PurgingDependencyTreeVisitor();
 
-    private final boolean validateSbomTrees;
-    private final TreeRecorder validatingTreeRecorder;
+    private final boolean validateSbomTrees = Boolean.parseBoolean(System.getProperty(DOMINO_VALIDATE_SBOM_TREES));
+    private final TreeRecorder validatingTreeRecorder = validateSbomTrees ? new TreeRecorder() : null;
+    private final ProjectDependencyConfig config;
+
+    public SbomGeneratingDependencyVisitor(MavenArtifactResolver resolver, Path outputFile, ProjectDependencyConfig config,
+            boolean enableSbomTransformers) {
+        sbomGenerator = SbomGenerator.builder()
+                .setArtifactResolver(resolver)
+                .setOutputFile(outputFile);
+        if (config.getProductInfo() != null) {
+            sbomGenerator.setProductInfo(config.getProductInfo());
+        }
+        this.config = config;
+    }
 
     public SbomGeneratingDependencyVisitor(MavenArtifactResolver resolver, Path outputFile, ProductInfo productInfo,
             boolean enableSbomTransformers) {
@@ -26,9 +43,7 @@ public class SbomGeneratingDependencyVisitor implements DependencyTreeVisitor {
                 .setArtifactResolver(resolver)
                 .setOutputFile(outputFile)
                 .setProductInfo(productInfo);
-        treeBuilder = new PurgingDependencyTreeVisitor();
-        validateSbomTrees = Boolean.parseBoolean(System.getProperty(DOMINO_VALIDATE_SBOM_TREES));
-        validatingTreeRecorder = validateSbomTrees ? new TreeRecorder() : null;
+        config = null;
     }
 
     @Override
@@ -42,14 +57,71 @@ public class SbomGeneratingDependencyVisitor implements DependencyTreeVisitor {
     @Override
     public void afterAllRoots() {
         treeBuilder.afterAllRoots();
-        sbomGenerator.setTopComponents(treeBuilder.getRoots());
+        final List<VisitedComponent> rootComponents = treeBuilder.getRoots();
+        sbomGenerator.setTopComponents(rootComponents);
+
+        if (sbomGenerator.getProductInfo() == null) {
+            VisitedComponent mainComponent = null;
+            if (rootComponents.size() == 1) {
+                mainComponent = rootComponents.get(0);
+            } else if (config.getProjectBom() != null) {
+                for (VisitedComponent c : rootComponents) {
+                    if (c.getArtifactCoords().equals(config.getProjectBom())) {
+                        mainComponent = c;
+                        break;
+                    }
+                }
+            }
+            if (mainComponent == null) {
+                for (VisitedComponent c : rootComponents) {
+                    if (!ArtifactCoords.TYPE_POM.equals(c.getArtifactCoords().getType())) {
+                        if (mainComponent == null) {
+                            mainComponent = c;
+                        } else {
+                            mainComponent = null;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (mainComponent != null) {
+                final ProductInfo.Mutable info = ProductInfo.builder()
+                        .setGroup(mainComponent.getArtifactCoords().getGroupId())
+                        .setName(mainComponent.getArtifactCoords().getArtifactId())
+                        .setVersion(mainComponent.getArtifactCoords().getVersion())
+                        .setPurl(mainComponent.getPurl().toString())
+                        .setType(Component.Type.LIBRARY.toString());
+                if (sbomGenerator.getArtifactResolver() != null
+                        && sbomGenerator.getArtifactResolver().getMavenContext().getWorkspace() != null) {
+                    var project = sbomGenerator.getArtifactResolver().getMavenContext().getWorkspace().getProject(
+                            mainComponent.getArtifactCoords().getGroupId(), mainComponent.getArtifactCoords().getArtifactId());
+                    if (project != null && mainComponent.getArtifactCoords().getVersion().equals(project.getVersion())) {
+                        setPomInfo(info, project);
+                    }
+                }
+                sbomGenerator.setProductInfo(info.build());
+            } else if (sbomGenerator.getArtifactResolver() != null
+                    && sbomGenerator.getArtifactResolver().getMavenContext().getCurrentProject() != null) {
+                var project = sbomGenerator.getArtifactResolver().getMavenContext().getCurrentProject();
+                final ProductInfo.Mutable info = ProductInfo.builder()
+                        .setGroup(project.getGroupId())
+                        .setName(project.getArtifactId())
+                        .setVersion(project.getVersion())
+                        .setPurl(PurgingDependencyTreeVisitor.getPurl(project.getAppArtifact()).toString())
+                        .setType(Component.Type.LIBRARY.toString());
+                setPomInfo(info, project);
+                sbomGenerator.setProductInfo(info.build());
+            }
+        }
+
         final Bom bom = sbomGenerator.build().generate();
 
         if (validatingTreeRecorder != null) {
             System.out.println("Validating recorded trees");
             validatingTreeRecorder.afterAllRoots();
-            final List<String> rootBomRefs = new ArrayList<>(treeBuilder.getRoots().size());
-            for (VisitedComponent root : treeBuilder.getRoots()) {
+            final List<String> rootBomRefs = new ArrayList<>(rootComponents.size());
+            for (VisitedComponent root : rootComponents) {
                 if (root.getBomRef() == null) {
                     throw new IllegalStateException("bom-ref is missing for " + root.getArtifactCoords().toCompactCoords());
                 }
@@ -133,4 +205,21 @@ public class SbomGeneratingDependencyVisitor implements DependencyTreeVisitor {
             validatingTreeRecorder.leaveBomImport(visit);
         }
     }
+
+    private static void setPomInfo(ProductInfo.Mutable productInfo, LocalProject project) {
+        productInfo.setDescription(getPomElement(project, p -> p.getRawModel().getDescription()));
+    }
+
+    private static <R> R getPomElement(LocalProject project, Function<LocalProject, R> func) {
+        var p = project;
+        while (p != null) {
+            var r = func.apply(p);
+            if (r != null) {
+                return r;
+            }
+            p = p.getLocalParent();
+        }
+        return null;
+    }
+
 }

--- a/domino/api/src/main/java/io/quarkus/domino/manifest/SbomGenerator.java
+++ b/domino/api/src/main/java/io/quarkus/domino/manifest/SbomGenerator.java
@@ -57,6 +57,10 @@ public class SbomGenerator {
             return this;
         }
 
+        public MavenArtifactResolver getArtifactResolver() {
+            return SbomGenerator.this.resolver;
+        }
+
         public Builder setOutputFile(Path outputFile) {
             ensureNotBuilt();
             SbomGenerator.this.outputFile = outputFile;
@@ -67,6 +71,10 @@ public class SbomGenerator {
             ensureNotBuilt();
             SbomGenerator.this.productInfo = productInfo;
             return this;
+        }
+
+        public ProductInfo getProductInfo() {
+            return SbomGenerator.this.productInfo;
         }
 
         public Builder setEnableTransformers(boolean enableTransformers) {

--- a/domino/api/src/test/java/io/quarkus/domino/manifest/ProjectManifestingTest.java
+++ b/domino/api/src/test/java/io/quarkus/domino/manifest/ProjectManifestingTest.java
@@ -1,0 +1,122 @@
+package io.quarkus.domino.manifest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.quarkus.bootstrap.resolver.maven.BootstrapMavenException;
+import io.quarkus.bootstrap.resolver.maven.MavenArtifactResolver;
+import io.quarkus.domino.ProjectDependencyConfig;
+import io.quarkus.domino.ProjectDependencyResolver;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.Function;
+import org.cyclonedx.exception.ParseException;
+import org.cyclonedx.model.Bom;
+import org.cyclonedx.model.Component;
+import org.cyclonedx.parsers.JsonParser;
+import org.junit.jupiter.api.Test;
+
+public class ProjectManifestingTest {
+
+    @Test
+    public void simplePom() {
+        assertSbomMainComponent("projects/simple-pom", ArtifactCoords.pom("org.acme", "acme-parent", "1.0"));
+    }
+
+    @Test
+    public void singleJar() {
+        assertSbomMainComponent("projects/single-jar-and-bom", ArtifactCoords.jar("org.acme", "acme-library", "1.0"));
+    }
+
+    @Test
+    public void projectBom() {
+        final ArtifactCoords bom = ArtifactCoords.pom("org.acme", "acme-bom", "1.0");
+        assertSbomMainComponent("projects/single-jar-and-bom", bom, config -> config.setProjectBom(bom));
+    }
+
+    private static void assertSbomMainComponent(String projectDirName, ArtifactCoords coords) {
+        assertSbomMainComponent(projectDirName, coords, null);
+    }
+
+    private static void assertSbomMainComponent(String projectDirName, ArtifactCoords expectedCoords,
+            Function<ProjectDependencyConfig.Mutable, ProjectDependencyConfig.Mutable> configurator) {
+        var projectDir = getResource(projectDirName);
+        var mainComponent = getMainComponent(getSbomForProjectDir(projectDir, configurator));
+
+        assertThat(mainComponent).isNotNull();
+        assertThat(mainComponent.getGroup()).isEqualTo(expectedCoords.getGroupId());
+        assertThat(mainComponent.getName()).isEqualTo(expectedCoords.getArtifactId());
+        assertThat(mainComponent.getVersion()).isEqualTo(expectedCoords.getVersion());
+        assertThat(mainComponent.getPurl()).isEqualTo(PurgingDependencyTreeVisitor.getPurl(expectedCoords).toString());
+        assertThat(mainComponent.getLicenseChoice()).isNotNull();
+        assertThat(mainComponent.getLicenseChoice().getLicenses().size()).isEqualTo(1);
+        var license = mainComponent.getLicenseChoice().getLicenses().get(0);
+        assertThat(license.getId()).isEqualTo("Apache-2.0");
+        assertThat(mainComponent.getDescription()).isEqualTo("Description of " + mainComponent.getName());
+        assertThat(mainComponent.getType()).isEqualTo(Component.Type.LIBRARY);
+    }
+
+    private static Bom getSbomForProjectDir(Path projectDir,
+            Function<ProjectDependencyConfig.Mutable, ProjectDependencyConfig.Mutable> configurator) {
+        Path output = null;
+        try {
+            output = Files.createTempFile("domino-test", "sbom");
+            final MavenArtifactResolver artifactResolver = MavenArtifactResolver.builder()
+                    .setOffline(true)
+                    .setCurrentProject(projectDir.toString())
+                    .build();
+            var configBuilder = ProjectDependencyConfig.builder()
+                    .setProjectDir(projectDir)
+                    .setWarnOnMissingScm(true)
+                    .setLegacyScmLocator(true);
+            if (configurator != null) {
+                configBuilder = configurator.apply(configBuilder);
+            }
+            var config = configBuilder.build();
+            ProjectDependencyResolver.builder()
+                    .setArtifactResolver(artifactResolver)
+                    .setDependencyConfig(config)
+                    .addDependencyTreeVisitor(new SbomGeneratingDependencyVisitor(artifactResolver, output, config, false))
+                    .build()
+                    .resolveDependencies();
+
+            try (BufferedReader reader = Files.newBufferedReader(output)) {
+                return new JsonParser().parse(reader);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+        } catch (IOException | BootstrapMavenException e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (output != null) {
+                output.toFile().deleteOnExit();
+            }
+        }
+    }
+
+    private static Component getMainComponent(Bom bom) {
+        var metadata = bom.getMetadata();
+        if (metadata == null) {
+            return null;
+        }
+        return metadata.getComponent();
+    }
+
+    private static Path getResource(String resourceName) {
+        var url = Thread.currentThread().getContextClassLoader().getResource(resourceName);
+        assertThat(url).isNotNull();
+        return toLocalPath(url);
+    }
+
+    private static Path toLocalPath(final URL url) {
+        try {
+            return Path.of(url.toURI());
+        } catch (URISyntaxException var2) {
+            throw new IllegalArgumentException("Failed to translate " + url + " to local path", var2);
+        }
+    }
+}

--- a/domino/api/src/test/resources/projects/simple-pom/pom.xml
+++ b/domino/api/src/test/resources/projects/simple-pom/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.acme</groupId>
+  <artifactId>acme-parent</artifactId>
+  <version>1.0</version>
+  <name>Acme Parent</name>
+  <packaging>pom</packaging>
+  <description>Description of acme-parent</description>
+  <scm>
+    <url>https://github.com/acme/acme-parent</url>
+    <tag>1.0</tag>
+  </scm>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+</project>

--- a/domino/api/src/test/resources/projects/single-jar-and-bom/bom/pom.xml
+++ b/domino/api/src/test/resources/projects/single-jar-and-bom/bom/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.acme</groupId>
+    <artifactId>acme-parent</artifactId>
+    <version>1.0</version>
+  </parent>
+  <artifactId>acme-bom</artifactId>
+  <name>Acme BOM</name>
+  <description>Description of acme-bom</description>
+  <packaging>pom</packaging>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>acme-library</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/domino/api/src/test/resources/projects/single-jar-and-bom/library/pom.xml
+++ b/domino/api/src/test/resources/projects/single-jar-and-bom/library/pom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.acme</groupId>
+    <artifactId>acme-parent</artifactId>
+    <version>1.0</version>
+  </parent>
+  <artifactId>acme-library</artifactId>
+  <name>Acme Library</name>
+  <description>Description of acme-library</description>
+</project>

--- a/domino/api/src/test/resources/projects/single-jar-and-bom/pom.xml
+++ b/domino/api/src/test/resources/projects/single-jar-and-bom/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.acme</groupId>
+  <artifactId>acme-parent</artifactId>
+  <version>1.0</version>
+  <name>Acme Parent</name>
+  <packaging>pom</packaging>
+  <description>Description of acme-parent</description>
+  <scm>
+    <url>https://github.com/acme/acme-parent</url>
+    <tag>1.0</tag>
+  </scm>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+  <modules>
+    <module>bom</module>
+    <module>library</module>
+  </modules>
+</project>


### PR DESCRIPTION
FYI @vibe13 
If product info isn't configured, it will now try picking one of the components that are top level (roots of the dependency trees) as the main component for a generated SBOM using the following strategy:
1. if there is only one top level component in an SBOM it will be picked as the main one;
2. if a project BOM was configured, the BOM artifact will be preferred as the main component;
3. if there is only one non-`pom` top level component (typically a jar) it will be picked as the main one;
4. if there was a `projectDir` configured, it will use the module the `projectDir` points to as the main component.