### PR TITLE
A list of non Red Hat version artifacts for redhat-version-rate option

### DIFF
--- a/domino/README.md
+++ b/domino/README.md
@@ -176,6 +176,8 @@ Total number of dependencies: 1075
 Red Hat version rate: 82.3%
 ```
 
+A list of non Red Hat version artifacts is provided when `--log-not-matched` option is added to the command.
+
 ##### Red Hat build of Apache Camel for Quarkus productization rate
 
 The following command will inspect dependencies of all the Camel Quarkus extensions that are managed by `quarkus-camel-bom` and calculate the rate of artifacts containing `redhat` version qualifier:

--- a/domino/app/src/main/java/io/quarkus/domino/cli/Quarkus.java
+++ b/domino/app/src/main/java/io/quarkus/domino/cli/Quarkus.java
@@ -25,6 +25,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -103,6 +104,10 @@ public class Quarkus implements Callable<Integer> {
     @CommandLine.Option(names = {
             "--redhat-version-rate" }, description = "Calculate the rate of redhat versions among the inspected dependencies")
     public boolean redhatVersionRate;
+
+    @CommandLine.Option(names = {
+            "--log-not-matched" }, description = "Provide more details in combination with other options", defaultValue = "false")
+    public boolean logNotMatched;
 
     @CommandLine.Option(names = {
             "--info" }, description = "Log basic Quarkus platform release information")
@@ -254,6 +259,15 @@ public class Quarkus implements Callable<Integer> {
             if (!allNodes.isEmpty()) {
                 log.info(String.format("%-32s: %s (%.1f%%)", "Artifacts with Red Hat versions",
                         redhatVersions, ((double) redhatVersions.get() * 100) / allNodes.size()));
+
+                if (logNotMatched) {
+                    log.info("");
+                    log.info("Non Red Hat version artifacts:");
+                    allNodes.keySet()
+                            .stream().sorted(Comparator.comparing(Object::toString))
+                            .filter(coords -> !RhVersionPattern.isRhVersion(coords.getVersion()))
+                            .forEach(coords -> log.info(String.format(" * %s", coords)));
+                }
             }
             log.info("");
         }


### PR DESCRIPTION
A list of non Red Hat version artifacts for redhat-version-rate option

Introduces `--log-not-matched` option that can be used in the future in combination with other options than just `--redhat-version-rate`.

Example command: `domino quarkus --version 3.8.5.SP1-redhat-00001 --members=quarkus-bom --redhat-version-rate --extension-versions='*redhat*' --log-not-matched`