### PR TITLE
Fix inclusion/exclusion inconsistency

### DIFF
--- a/domino/api/src/test/java/io/quarkus/domino/ProjectDependencyResolverTest.java
+++ b/domino/api/src/test/java/io/quarkus/domino/ProjectDependencyResolverTest.java
@@ -46,6 +46,24 @@ public class ProjectDependencyResolverTest {
     }
 
     @Test
+    public void singleJarInclusionBeatsExclusion() throws Exception {
+
+        var rc = getReleaseCollection(TestUtils.getResource("projects/multimodule-with-bom"),
+                List.of(ArtifactCoords.jar("org.acme", "acme-library", "1.0")),
+                config -> config.setExcludeKeys(List.of(ArtifactKey.ga("org.acme", "acme-api")))
+                        .setIncludeKeys(List.of(ArtifactKey.ga("org.acme", "acme-api"))));
+
+        assertThat(rc.isEmpty()).isFalse();
+        assertThat(rc.size()).isEqualTo(1);
+        var release = rc.iterator().next();
+        assertThat(release.artifacts).hasSize(4);
+        assertThat(release.getArtifacts()).containsKey(ArtifactCoords.pom("org.acme", "acme-parent", "1.0"));
+        assertThat(release.getArtifacts()).containsKey(ArtifactCoords.pom("org.acme", "acme-bom", "1.0"));
+        assertThat(release.getArtifacts()).containsKey(ArtifactCoords.jar("org.acme", "acme-api", "1.0"));
+        assertThat(release.getArtifacts()).containsKey(ArtifactCoords.jar("org.acme", "acme-library", "1.0"));
+    }
+
+    @Test
     public void singleJarArtifactIncludingParentPomsAndBoms() throws Exception {
 
         var rc = getReleaseCollection(TestUtils.getResource("projects/single-jar-and-bom"),


### PR DESCRIPTION
Closes #320

If we decide a root artefact is allowed by the include/exclude list we use the same logic to decide if we should process it as a node.

Note this changes the behaviour, an inclusion rule will beat an exclusion rule.

## Context

We are [using ProjectDependencyResolver](https://github.com/project-ncl/bacon/blob/main/experimental/src/main/java/org/jboss/bacon/experimental/impl/dependencies/DependencyResolver.java#L57) to discover project dependencies and want to be able to configure it like:

```
excludePattern: "org.group:*:*"
includePattern: "org.group:specific:*"
```

However in this configuration `org.group:specific:*` is not resolved as the exclusion takes precedence.  Then looking into the code we see some usages where inclusion beats exclusion and wonder what the intent of the inclusion/exclusion lists are.

This is more the start of a conversation as there are numerous places where the include/exclude list are consulted. For example when collecting projectBomConstraints it has different logic again:
```
if (includeSet.isEmpty()) {
                    collect = d.getGroupId().startsWith(config.getProjectBom().getGroupId()) && !isExclude(d);
                } else {
                    collect = !isExcluded(d) && isIncluded(d);
                }
```
where it applies this groupId restriction if there are no explicit inclusions else it requires it to be explicitly included.

There are other places in the resolver where we only check the exclusion list or inclusion list.

The javadoc on ProjectDependencyConfig is ambiguous around how `getIncludePatterns` and `getExcludePatterns`  interact and how they relate to `getIncludeArtifacts`.

It feels like there should be some consistent way that the inclusion/exclusion rules are applied to dependencies.