### PR TITLE
Re-use remote repos injected in the mojo when creating a collect request during the platform project generation

### DIFF
--- a/maven-plugin/src/main/java/io/quarkus/bom/decomposer/maven/platformgen/GeneratePlatformProjectMojo.java
+++ b/maven-plugin/src/main/java/io/quarkus/bom/decomposer/maven/platformgen/GeneratePlatformProjectMojo.java
@@ -1315,7 +1315,7 @@ public class GeneratePlatformProjectMojo extends AbstractMojo {
                             new DefaultArtifact(ModelUtils.getGroupId(pom), pom.getArtifactId(), ArtifactCoords.TYPE_POM,
                                     ModelUtils.getVersion(pom)),
                             directAetherDeps, toAetherDependencies(pom.getDependencyManagement().getDependencies()),
-                            List.of(), List.of()))
+                            List.of(), getNonWorkspaceResolver().getRepositories()))
                     .getRoot();
         } catch (DependencyCollectionException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
This fixes an issue when we enable repositories in a profile in the platform project.