### PR TITLE
Prepare upgrade to recent Quarkus version as part of reproducible builds

### DIFF
--- a/maven-plugin/src/main/java/io/quarkus/bom/decomposer/maven/GeneratePlatformDescriptorJsonMojo.java
+++ b/maven-plugin/src/main/java/io/quarkus/bom/decomposer/maven/GeneratePlatformDescriptorJsonMojo.java
@@ -747,17 +747,12 @@ public class GeneratePlatformDescriptorJsonMojo extends AbstractMojo {
         }
 
         Extension.Mutable e = null;
-        Path json = metaInfDir.resolve(BootstrapConstants.EXTENSION_PROPS_JSON_FILE_NAME);
-        if (!Files.exists(json)) {
-            final Path props = metaInfDir.resolve(BootstrapConstants.DESCRIPTOR_FILE_NAME);
-            if (Files.exists(props)) {
-                e = Extension.builder();
-                e.setArtifact(ArtifactCoords.of(artifact.getGroupId(), artifact.getArtifactId(),
-                        artifact.getClassifier(), artifact.getExtension(), artifact.getVersion()));
-                e.setName(artifact.getArtifactId());
-            }
-        } else {
-            e = processPlatformArtifact(artifact, json);
+        final Path props = metaInfDir.resolve(BootstrapConstants.DESCRIPTOR_FILE_NAME);
+        if (Files.exists(props)) {
+            e = Extension.builder();
+            e.setArtifact(ArtifactCoords.of(artifact.getGroupId(), artifact.getArtifactId(),
+                    artifact.getClassifier(), artifact.getExtension(), artifact.getVersion()));
+            e.setName(artifact.getArtifactId());
         }
         return e;
     }

--- a/maven-plugin/src/main/java/io/quarkus/maven/ValidateExtensionsJsonMojo.java
+++ b/maven-plugin/src/main/java/io/quarkus/maven/ValidateExtensionsJsonMojo.java
@@ -228,8 +228,7 @@ public class ValidateExtensionsJsonMojo extends AbstractMojo {
             final Path metaInf = visit.getPath();
             final Path descrProps = metaInf.resolve(BootstrapConstants.DESCRIPTOR_FILE_NAME);
             final Path descrYaml = metaInf.resolve(BootstrapConstants.QUARKUS_EXTENSION_FILE_NAME);
-            final Path descrJson = metaInf.resolve(BootstrapConstants.EXTENSION_PROPS_JSON_FILE_NAME);
-            if (ensureExtensionMetadata(artifact, descrProps, descrYaml, descrJson)) {
+            if (ensureExtensionMetadata(artifact, descrProps, descrYaml)) {
                 final ArtifactCoords deployment = readDeploymentCoords(descrProps, artifact);
                 final ArtifactKey key = ArtifactKey.of(artifact.getGroupId(), artifact.getArtifactId(),
                         artifact.getClassifier(),
@@ -257,9 +256,9 @@ public class ValidateExtensionsJsonMojo extends AbstractMojo {
         return deployment;
     }
 
-    private static boolean ensureExtensionMetadata(Artifact a, Path properties, Path yaml, Path json) {
+    private static boolean ensureExtensionMetadata(Artifact a, Path properties, Path yaml) {
         final boolean propsExist = Files.exists(properties);
-        final boolean metadataExists = Files.exists(yaml) || Files.exists(json);
+        final boolean metadataExists = Files.exists(yaml);
         if (propsExist == metadataExists) {
             return propsExist;
         }

--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
     <commons-text.version>1.12.0</commons-text.version>
     <gradle-tooling.version>8.1.1</gradle-tooling.version>
     <quarkus.version>3.24.5</quarkus.version>
-    <quarkus-jgit.version>3.3.3</quarkus-jgit.version>
-    <jgit.version>7.0.0.202409031743-r</jgit.version>
+    <quarkus-jgit.version>3.6.0</quarkus-jgit.version>
+    <jgit.version>7.3.0.202506031305-r</jgit.version>
     <json-unit-assertj.version>3.2.7</json-unit-assertj.version>
     <junit.jupiter.version>5.10.2</junit.jupiter.version>
     <hacbs-recipies-database.version>0.7</hacbs-recipies-database.version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <assertj.version>3.25.3</assertj.version>
     <commons-text.version>1.12.0</commons-text.version>
     <gradle-tooling.version>8.1.1</gradle-tooling.version>
-    <quarkus.version>3.15.5</quarkus.version>
+    <quarkus.version>3.24.5</quarkus.version>
     <quarkus-jgit.version>3.3.3</quarkus-jgit.version>
     <jgit.version>7.0.0.202409031743-r</jgit.version>
     <json-unit-assertj.version>3.2.7</json-unit-assertj.version>


### PR DESCRIPTION
In Quarkus, I modified the JSON mapper to be more reproducible, we had issues with the order of properties not being stable in the generated JSON file.

This will require an update of the Quarkus version used, which I think shouldn't be an issue.

There's one issue though: a constant has been dropped but AFAICS, we changed to a YAML file in 0.27.0 so a veeeerrrryyyy long time ago.

Note: this will be a bit disruptive as the generated Platform will probably contain a lot of changes compared to what was generated. But it should be a lot more stable after that.