### PR TITLE
Add version resolution and light validation from BOM for integrates metadata field for the extensions

### DIFF
--- a/integration-tests/platform-generator/src/test/java/io/quarkus/maven/project/ExtensionIntegrates.java
+++ b/integration-tests/platform-generator/src/test/java/io/quarkus/maven/project/ExtensionIntegrates.java
@@ -1,0 +1,30 @@
+package io.quarkus.maven.project;
+
+/**
+ * Represents an "integrates" metadata entry in a Quarkus extension descriptor.
+ * Used to declare which external libraries the extension integrates with.
+ */
+public class ExtensionIntegrates {
+
+    private final String name;
+    private final String artifact;
+    private final String version;
+
+    public ExtensionIntegrates(String name, String artifact, String version) {
+        this.name = name;
+        this.artifact = artifact;
+        this.version = version;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getArtifact() {
+        return artifact;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+}

--- a/integration-tests/platform-generator/src/test/java/io/quarkus/maven/project/MavenModuleGenerator.java
+++ b/integration-tests/platform-generator/src/test/java/io/quarkus/maven/project/MavenModuleGenerator.java
@@ -154,6 +154,43 @@ public class MavenModuleGenerator {
         return addModule(moduleName).setPackaging(ArtifactCoords.TYPE_POM);
     }
 
+    /**
+     * Adds integrates metadata to a Quarkus extension's quarkus-extension.yaml file.
+     * This creates the YAML file with artifact, name, and integrates metadata.
+     *
+     * @param integrates List of integrates entries
+     * @return this module generator for chaining
+     */
+    public MavenModuleGenerator addExtensionIntegratesMetadata(List<ExtensionIntegrates> integrates) {
+        return addPostGenerateTask(moduleDir -> {
+            try {
+                var metaInf = Files.createDirectories(
+                        moduleDir.resolve("src").resolve("main").resolve("resources").resolve("META-INF"));
+                var yamlFile = metaInf.resolve(BootstrapConstants.QUARKUS_EXTENSION_FILE_NAME);
+
+                var content = new StringBuilder();
+                content.append("---\n");
+                content.append("artifact: \"").append(getGroupId()).append(':')
+                        .append(getArtifactId()).append(':').append(getVersion()).append("\"\n");
+                content.append("name: \"").append(getArtifactId()).append("\"\n");
+
+                if (integrates != null && !integrates.isEmpty()) {
+                    content.append("metadata:\n");
+                    content.append("  integrates:\n");
+                    for (var entry : integrates) {
+                        content.append("    - name: \"").append(entry.getName()).append("\"\n");
+                        content.append("      artifact: \"").append(entry.getArtifact()).append("\"\n");
+                        content.append("      version: \"").append(entry.getVersion()).append("\"\n");
+                    }
+                }
+
+                Files.writeString(yamlFile, content.toString());
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        });
+    }
+
     public MavenModuleGenerator addVersionConstraint(MavenModuleGenerator module) {
         return addVersionConstraint(module.getGroupId(), module.getArtifactId(), module.getVersion());
     }

--- a/integration-tests/platform-generator/src/test/java/io/quarkus/platform/generator/test/IntegratesVersionResolutionTest.java
+++ b/integration-tests/platform-generator/src/test/java/io/quarkus/platform/generator/test/IntegratesVersionResolutionTest.java
@@ -1,0 +1,128 @@
+package io.quarkus.platform.generator.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.quarkus.maven.project.ExtensionIntegrates;
+import io.quarkus.platform.generator.PlatformTestProjectGenerator;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class IntegratesVersionResolutionTest {
+
+    @TempDir
+    Path workingDir;
+
+    @Test
+    void testIntegratesVersionResolvedFromExplicitBomConstraint() throws Exception {
+        var platformGenerator = PlatformTestProjectGenerator.newInstance();
+
+        var jackson10 = platformGenerator.configureProject("org.jackson", "jackson-parent", "1.0")
+                .setScm("https://jackson.org", "1.0");
+        var jacksonLibA10 = jackson10.addModule("jackson-lib-a");
+
+        var jackson20 = platformGenerator.configureProject("org.jackson", "jackson-parent", "2.0")
+                .setScm("https://jackson.org", "2.0");
+        var jacksonLibA20 = jackson20.addModule("jackson-lib-a");
+
+        var camelProject = platformGenerator.configureProject("org.camel", "camel-parent", "1.0")
+                .setScm("https://camel.org", "1.0");
+        var camelAtom = camelProject.addQuarkusExtensionRuntimeModule("camel-atom")
+                .addExtensionIntegratesMetadata(List.of(
+                        new ExtensionIntegrates("Jackson Lib A", "org.jackson:jackson-lib-a", "1.0")));
+
+        var camelBom = camelProject.addPomModule("camel-bom")
+                .addVersionConstraint(camelAtom) // version constraint
+                .addVersionConstraint(jacksonLibA20);
+
+        var platform = platformGenerator
+                .setProjectDir(workingDir)
+                .addMember("Camel", camelBom)
+                .generateProject()
+                .build();
+
+        assertThat(platform.getCore()).isNotNull();
+        assertThat(platform.getCore().getExtensionCatalog()).isNotNull();
+
+        var camelExtensions = platform.getMember("Camel").getExtensionCatalog().getExtensions();
+        var camelAtomExt = camelExtensions.stream()
+                .filter(ext -> ext.getArtifact().getArtifactId().equals("camel-atom"))
+                .findFirst();
+
+        assertThat(camelAtomExt).as("camel-atom extension should be present").isPresent();
+
+        Map<String, Object> camelMetadata = camelAtomExt.get().getMetadata();
+        assertThat(camelMetadata).containsKey("integrates");
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, String>> camelIntegrates = (List<Map<String, String>>) camelMetadata.get("integrates");
+        assertThat(camelIntegrates).hasSize(1);
+
+        Map<String, String> jacksonEntry = camelIntegrates.get(0);
+        assertThat(jacksonEntry.get("name")).isEqualTo("Jackson Lib A");
+        assertThat(jacksonEntry.get("artifact")).isEqualTo("org.jackson:jackson-lib-a");
+        assertThat(jacksonEntry.get("version"))
+                .as("Jackson version in camel-atom should be upgraded from 1.0 to 2.0 to match camel BOM")
+                .isEqualTo("2.0");
+    }
+
+    @Test
+    void testIntegratesVersionResolvedFromImportedBom() throws Exception {
+        var platformGenerator = PlatformTestProjectGenerator.newInstance();
+
+        var jackson10 = platformGenerator.configureProject("org.jackson", "jackson-parent", "1.0")
+                .setScm("https://jackson.org", "1.0");
+        var jacksonLibA10 = jackson10.addModule("jackson-lib-a");
+        var jacksonBom10 = jackson10.addPomModule("jackson-bom")
+                .addVersionConstraint(jacksonLibA10);
+
+        var jackson20 = platformGenerator.configureProject("org.jackson", "jackson-parent", "2.0")
+                .setScm("https://jackson.org", "2.0");
+        var jacksonLibA20 = jackson20.addModule("jackson-lib-a");
+        var jacksonBom20 = jackson20.addPomModule("jackson-bom")
+                .addVersionConstraint(jacksonLibA20);
+
+        var camelProject = platformGenerator.configureProject("org.camel", "camel-parent", "1.0")
+                .setScm("https://camel.org", "1.0");
+        var camelAtom = camelProject.addQuarkusExtensionRuntimeModule("camel-atom")
+                .addExtensionIntegratesMetadata(List.of(
+                        new ExtensionIntegrates("Jackson Lib A", "org.jackson:jackson-lib-a", "1.0")));
+
+        var camelBom = camelProject.addPomModule("camel-bom")
+                .importBom(jacksonBom20)
+                .addVersionConstraint(camelAtom);
+
+        var platform = platformGenerator
+                .setProjectDir(workingDir)
+                .addMember("Camel", camelBom)
+                .generateProject()
+                .build();
+
+        assertThat(platform.getCore()).isNotNull();
+        assertThat(platform.getCore().getExtensionCatalog()).isNotNull();
+
+        var camelExtensions = platform.getMember("Camel").getExtensionCatalog().getExtensions();
+        var camelAtomExt = camelExtensions.stream()
+                .filter(ext -> ext.getArtifact().getArtifactId().equals("camel-atom"))
+                .findFirst();
+
+        assertThat(camelAtomExt).as("camel-atom extension should be present").isPresent();
+
+        Map<String, Object> camelMetadata = camelAtomExt.get().getMetadata();
+        assertThat(camelMetadata).containsKey("integrates");
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, String>> camelIntegrates = (List<Map<String, String>>) camelMetadata.get("integrates");
+        assertThat(camelIntegrates).hasSize(1);
+
+        Map<String, String> jacksonEntry = camelIntegrates.get(0);
+        assertThat(jacksonEntry.get("name")).isEqualTo("Jackson Lib A");
+        assertThat(jacksonEntry.get("artifact")).isEqualTo("org.jackson:jackson-lib-a");
+        assertThat(jacksonEntry.get("version"))
+                .as("Version should be upgraded from 1.0 to 2.0 via BOM import - " +
+                        "Maven's getManagedDependencies() expands <scope>import</scope> BOMs")
+                .isEqualTo("2.0");
+    }
+}

--- a/maven-plugin/src/main/java/io/quarkus/bom/decomposer/maven/GeneratePlatformDescriptorJsonMojo.java
+++ b/maven-plugin/src/main/java/io/quarkus/bom/decomposer/maven/GeneratePlatformDescriptorJsonMojo.java
@@ -384,7 +384,8 @@ public class GeneratePlatformDescriptorJsonMojo extends AbstractMojo {
                     extension = processDependency(
                             repoSystem.resolveArtifact(repoSession,
                                     new ArtifactRequest().setRepositories(repos).setArtifact(artifact))
-                                    .getArtifact());
+                                    .getArtifact(),
+                            deps);
                 } catch (ArtifactResolutionException e) {
                     // there are some parent poms that appear as jars for some reason
                     debug("Failed to resolve dependency %s defined in %s", artifact, bomArtifact);
@@ -714,13 +715,14 @@ public class GeneratePlatformDescriptorJsonMojo extends AbstractMojo {
         return value;
     }
 
-    private Extension.Mutable processDependency(Artifact artifact) throws IOException, MojoExecutionException {
+    private Extension.Mutable processDependency(Artifact artifact, List<Dependency> bomDependencies)
+            throws IOException, MojoExecutionException {
         final Path path = artifact.getFile().toPath();
         if (Files.isDirectory(path)) {
-            return processMetaInfDir(artifact, path.resolve(BootstrapConstants.META_INF));
+            return processMetaInfDir(artifact, path.resolve(BootstrapConstants.META_INF), bomDependencies);
         } else {
             try (FileSystem artifactFs = ZipUtils.newFileSystem(path)) {
-                return processMetaInfDir(artifact, artifactFs.getPath(BootstrapConstants.META_INF));
+                return processMetaInfDir(artifact, artifactFs.getPath(BootstrapConstants.META_INF), bomDependencies);
             }
         }
     }
@@ -734,7 +736,7 @@ public class GeneratePlatformDescriptorJsonMojo extends AbstractMojo {
      * @throws IOException
      * @throws MojoExecutionException
      */
-    private Extension.Mutable processMetaInfDir(Artifact artifact, Path metaInfDir)
+    private Extension.Mutable processMetaInfDir(Artifact artifact, Path metaInfDir, List<Dependency> bomDependencies)
             throws IOException, MojoExecutionException {
 
         if (!Files.exists(metaInfDir)) {
@@ -743,7 +745,7 @@ public class GeneratePlatformDescriptorJsonMojo extends AbstractMojo {
 
         Path yaml = metaInfDir.resolve(BootstrapConstants.QUARKUS_EXTENSION_FILE_NAME);
         if (Files.exists(yaml)) {
-            return processPlatformArtifact(artifact, yaml);
+            return processPlatformArtifact(artifact, yaml, bomDependencies);
         }
 
         Extension.Mutable e = null;
@@ -757,10 +759,12 @@ public class GeneratePlatformDescriptorJsonMojo extends AbstractMojo {
         return e;
     }
 
-    private Extension.Mutable processPlatformArtifact(Artifact artifact, Path descriptor)
+    private Extension.Mutable processPlatformArtifact(Artifact artifact, Path descriptor, List<Dependency> bomDependencies)
             throws IOException, MojoExecutionException {
         final Extension.Mutable legacy = Extension.mutableFromFile(descriptor);
         final Extension.Mutable object = transformLegacyToNew(legacy);
+        // Resolve integrates versions from BOM
+        resolveIntegratesVersions(object, bomDependencies);
         if (object.getArtifact() == null) {
             throw new MojoExecutionException(descriptor + " of " + artifact
                     + " is missing the artifact coordinates, please make sure the extension metadata is complete");
@@ -836,6 +840,97 @@ public class GeneratePlatformDescriptorJsonMojo extends AbstractMojo {
             metadata.remove("labels");
         }
         return extObject;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void resolveIntegratesVersions(Extension.Mutable extObject, List<Dependency> bomDependencies)
+            throws MojoExecutionException {
+        if (bomDependencies == null) {
+            if (getLog().isDebugEnabled()) {
+                debug("bomDependencies is null, skipping integrates resolution");
+            }
+            return;
+        }
+
+        final Map<String, Object> metadata = extObject.getMetadata();
+        final Object integratesObj = metadata.get("integrates");
+        if (integratesObj == null) {
+            return;
+        }
+
+        if (!(integratesObj instanceof List)) {
+            throw new MojoExecutionException("Extension " + extObject.getArtifact()
+                    + " has invalid 'integrates' metadata: expected a List but got "
+                    + integratesObj.getClass().getName());
+        }
+
+        if (getLog().isDebugEnabled()) {
+            debug("Processing integrates for extension: %s", extObject.getArtifact());
+            debug("BOM has %d managed dependencies", bomDependencies.size());
+            for (Dependency dep : bomDependencies) {
+                debug("  BOM dependency: %s:%s:%s",
+                        dep.getArtifact().getGroupId(),
+                        dep.getArtifact().getArtifactId(),
+                        dep.getArtifact().getVersion());
+            }
+        }
+
+        List<Map<String, String>> integratesList = (List<Map<String, String>>) integratesObj;
+        for (int i = 0; i < integratesList.size(); i++) {
+            Map<String, String> integrates = integratesList.get(i);
+
+            // Validate mandatory fields
+            String name = integrates.get("name");
+            String artifact = integrates.get("artifact");
+            String version = integrates.get("version");
+
+            if (name == null || name.isEmpty()) {
+                throw new MojoExecutionException("Extension " + extObject.getArtifact()
+                        + " has 'integrates' entry at index " + i + " missing mandatory 'name' field");
+            }
+            if (artifact == null || artifact.isEmpty()) {
+                throw new MojoExecutionException("Extension " + extObject.getArtifact()
+                        + " has 'integrates' entry at index " + i + " (name: '" + name
+                        + "') missing mandatory 'artifact' field");
+            }
+            if (version == null || version.isEmpty()) {
+                throw new MojoExecutionException("Extension " + extObject.getArtifact()
+                        + " has 'integrates' entry at index " + i + " (name: '" + name
+                        + "') missing mandatory 'version' field");
+            }
+
+            // Parse artifact coordinates (format: "groupId:artifactId")
+            String[] parts = artifact.split(":");
+            if (parts.length != 2) {
+                throw new MojoExecutionException("Extension " + extObject.getArtifact()
+                        + " has 'integrates' entry '" + name + "' with invalid artifact format: '" + artifact
+                        + "'. Expected format: 'groupId:artifactId'");
+            }
+
+            String groupId = parts[0];
+            String artifactId = parts[1];
+
+            // Look up artifact in BOM
+            String bomVersion = null;
+            for (Dependency dep : bomDependencies) {
+                if (dep.getArtifact().getGroupId().equals(groupId)
+                        && dep.getArtifact().getArtifactId().equals(artifactId)) {
+                    bomVersion = dep.getArtifact().getVersion();
+                    break;
+                }
+            }
+
+            // If found in BOM, validate and override version if different
+            if (bomVersion != null) {
+                if (!version.equals(bomVersion)) {
+                    getLog().info("Upgrading " + name + " " + version + " -> " + bomVersion + " in "
+                            + extObject.getArtifact() + "'s extension metadata to match the version of " + artifact
+                            + " in Platform BOMs");
+                    integrates.put("version", bomVersion);
+                }
+            }
+            // If not in BOM, keep the provided version as-is (no action needed)
+        }
     }
 
     public OverrideInfo getOverrideInfo(File overridesFile) throws MojoExecutionException {

--- a/maven-plugin/src/main/java/io/quarkus/maven/ValidateExtensionsJsonMojo.java
+++ b/maven-plugin/src/main/java/io/quarkus/maven/ValidateExtensionsJsonMojo.java
@@ -268,4 +268,5 @@ public class ValidateExtensionsJsonMojo extends AbstractMojo {
         throw new RuntimeException(
                 a + " includes Quarkus extension properties but not " + BootstrapConstants.EXTENSION_METADATA_PATH);
     }
+
 }


### PR DESCRIPTION
Ref https://github.com/quarkusio/quarkus/issues/35404

This is a proposal to add the new `integrates` section in the extension metadatas like:
```
metadata:                                                                                                                                                                        
      integrates:                                                                                                                                                                    
      - name: "Hibernate ORM"                                                                                                                                                      
        resolveVersionFrom: "org.hibernate.orm:hibernate-core"                                                                                                                     
      - name: "Some Library"                                                                                                                                                       
        version: "1.2.3" 
```
Each entry must have:                                                                                                                                                            
* `name` (required): Display name for the integrated library                                                                                                                     
* Version (one of):                                                                                                                                                              
** `resolveVersionFrom`: `groupId:artifactId` to resolve from the platform BOM (recommended)                                                                                     
** `version`: A literal version string                                                                                                                                           
If the `version` field is not given, the `resolveVersionFrom` field is automatically resolved during platform descriptor generation and the `version` field is populated from the platform BOM.

From my understanding the `validate-extension-catalog` runs on a generated platform BOM, so I added a validation that logs some warning if there is something wrong with the integrated metadatas.