### PR TITLE
Update DA URL to the new one after the DA re-write

### DIFF
--- a/domino/api/src/main/java/io/quarkus/domino/pnc/PncVersionProvider.java
+++ b/domino/api/src/main/java/io/quarkus/domino/pnc/PncVersionProvider.java
@@ -23,7 +23,7 @@ import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 
 public class PncVersionProvider {
 
-    private static final String LATEST_VERSION_REQUEST_URL = "https://da.pnc.engineering.redhat.com/da/rest/v-1/lookup/maven/latest";
+    private static final String LATEST_VERSION_REQUEST_URL = "https://da.pnc.engineering.redhat.com/rest/v-1/lookup/maven/latest";
 
     private static volatile ObjectMapper mapper;
 


### PR DESCRIPTION
DA was re-written in Quarkus so the URL changed from `https://da.pnc.engineering.redhat.com/da/rest/v-1/lookup/maven/latest` to `https://da.pnc.engineering.redhat.com/rest/v-1/lookup/maven/latest` - the announcement for this was attached to the Bacon 3.5.0 release email.