### PR TITLE
Add product and support information to platform properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,16 @@ e.g. `platform.com.redhat.quarkus.platform.quarkus-camel-bom.cpe=cpe:2.3:a:redha
 
 Each member's CPE is written only into that member's own properties file, so a consumer only ever sees the CPE for members whose BOM it actually imports. A consumer (e.g. the Quarkus SBOM generator) resolves a member's CPE by reading the aggregated platform properties (`ApplicationModel.getPlatformProperties()`) and, for each member BOM enumerated via `PlatformReleaseInfo.getBoms()`, looking up `platform.<groupId>.<artifactId>.cpe`. A missing key means the member has no CPE configured.
 
+### Member CPE artifacts property
+
+When a member declares both a CPE and an offering, the generator also writes a companion property that records, for each supported runtime extension artifact, the deployment dependency closure a consumer should attribute to the member's CPE:
+
+```
+platform.<member-bom-groupId>.<member-bom-artifactId>.cpe-artifacts=<base64>
+```
+
+The value is a lossless, Deflate-compressed and Base64-encoded encoding of the runtime-extension → deployment-closure map. Its format and how to decode it (including from other languages) are documented in [docs/cpe-artifacts-serialization.md](docs/cpe-artifacts-serialization.md).
+
 ## Release
 
 To release a new version, follow these steps:

--- a/README.md
+++ b/README.md
@@ -200,6 +200,34 @@ Each directory currently contains:
 * original-releases.html - multi-module releases detected in the original version of the BOM.
 * generated-releases.html - multi-module releases detected in the generated version of the BOM.
 
+### Member CPE platform property
+
+If a platform member declares a product CPE (Common Platform Enumeration) in its SBOM product configuration, e.g.
+
+```
+                    <members>
+                        <member>
+                            <name>Camel</name>
+                            <bom>...</bom>
+                            <sbom>
+                                <productInfo>
+                                    <cpe>cpe:2.3:a:redhat:camel_quarkus:3.33:*:*:*:*:*:*:*</cpe>
+                                </productInfo>
+                            </sbom>
+                        </member>
+                    </members>
+```
+
+the generator writes it into that member's generated `platform-properties.properties` as a property keyed by the *generated* member BOM coordinates:
+
+```
+platform.<member-bom-groupId>.<member-bom-artifactId>.cpe=<cpe>
+```
+
+e.g. `platform.com.redhat.quarkus.platform.quarkus-camel-bom.cpe=cpe:2.3:a:redhat:camel_quarkus:3.33:*:*:*:*:*:*:*`.
+
+Each member's CPE is written only into that member's own properties file, so a consumer only ever sees the CPE for members whose BOM it actually imports. A consumer (e.g. the Quarkus SBOM generator) resolves a member's CPE by reading the aggregated platform properties (`ApplicationModel.getPlatformProperties()`) and, for each member BOM enumerated via `PlatformReleaseInfo.getBoms()`, looking up `platform.<groupId>.<artifactId>.cpe`. A missing key means the member has no CPE configured.
+
 ## Release
 
 To release a new version, follow these steps:

--- a/docs/cpe-artifacts-serialization.md
+++ b/docs/cpe-artifacts-serialization.md
@@ -1,0 +1,148 @@
+# `cpe-artifacts` platform property serialization
+
+This document describes the format of the `cpe-artifacts` platform property produced by the platform BOM generator, so that the Quarkus SBOM generator can decode it.
+
+## What the property records
+
+When a platform member declares both a product CPE and an offering, the
+generator records, for each supported **runtime** extension artifact of that
+member, the set of artifacts a consumer should attribute to the member's CPE.
+
+The data is a map:
+
+```
+runtime extension artifact  →  its deployment artifact + the resolved
+                               deployment dependency closure (aligned to the
+                               versions the platform ships)
+```
+
+Keying by the runtime artifact lets a consumer look up the runtime artifacts it
+already has in its `ApplicationModel` directly, without mapping them to their
+deployment counterparts itself.
+
+## Property key
+
+The value is written into the member's generated `platform-properties.properties`
+keyed by the *generated* member BOM coordinates:
+
+```
+platform.<member-bom-groupId>.<member-bom-artifactId>.cpe-artifacts=<base64>
+```
+
+The property is present only when the member declares both a CPE and an
+offering. Base64's alphabet contains no `${`, so Maven resource filtering leaves
+the value untouched.
+
+## Compression pipeline
+
+The value is an exact encoding of the map. It is produced with JDK APIs only — no third-party dependencies:
+
+**Encode:** build the text format below → UTF-8 bytes →
+`java.util.zip.Deflater` with `BEST_COMPRESSION` → `Base64` (standard alphabet,
+no line breaks).
+
+**Decode:** `Base64.getDecoder().decode(value)` → `java.util.zip.Inflater` →
+UTF-8 string → parse the text format below.
+
+The compressed stream is a standard zlib/DEFLATE stream, so any language's
+zlib binding can inflate it; the compression level is not needed for
+decompression.
+
+## Text format
+
+Coordinates recur heavily across entries (deployment closures overlap between
+extensions), and even distinct coordinates share groupIds, versions and
+artifactId prefixes. To remove this repetition — most of which lies beyond
+DEFLATE's 32&nbsp;KB window — the text has two sections separated by a line
+containing exactly `--`:
+
+1. a **dictionary** of every distinct coordinate, grouped so shared parts are
+   written once;
+2. the **entries**, which reference the dictionary by index.
+
+```
+@org.apache.camel.quarkus     ← groupId; the NEXT line is this group's common artifactId prefix
+camel-quarkus-                ← positional prefix line (empty when there is no shared prefix)
+=3.33.0                       ← version sub-block
+core                          ← artifactId minus prefix → camel-quarkus-core     (classifier "", type jar)
+support:linux-x86_64          ← camel-quarkus-support, classifier linux-x86_64, type jar
+=3.20.0                       ← further versions reuse the same groupId + prefix
+legacy                        ← camel-quarkus-legacy
+@io.quarkus
+quarkus-core                  ← prefix equals the only artifactId (singleton group)
+=3.15.0
+                              ← empty artifact line ⇒ artifactId equals the prefix exactly
+--
+1a[0,3,5]                     ← entry: runtime-key index, then delta-encoded dependency indices
+```
+
+### Dictionary section
+
+Each line is self-identifying by its first character:
+
+| Line              | Meaning |
+|-------------------|---------|
+| `@groupId`        | Starts a group. The **very next line** is this group's common artifactId prefix. |
+| *(line after `@`)*| The group's common artifactId prefix — **positional, always present**, and empty when the group has no shared prefix. |
+| `=version`        | Starts a version sub-block within the current group. |
+| *(anything else)* | An **artifact line** (see below). |
+
+An artifact line is the artifactId with the group prefix stripped, optionally
+followed by `:classifier` and/or `:type`. Trailing default parts are omitted:
+
+| Artifact line              | Reconstructed coordinate (with prefix `P`, group `G`, version `V`) |
+|----------------------------|-------------------------------------------------------------------|
+| `rem`                      | `G:` `P+rem` `::jar:V`  (empty classifier, `jar` type) |
+| `rem:cls`                  | classifier `cls`, type `jar` |
+| `rem::type`                | empty classifier, type `type` |
+| `rem:cls:type`             | classifier `cls`, type `type` |
+| *(empty line)*             | artifactId equals the prefix exactly (`P`), empty classifier, `jar` type |
+| `:cls`                     | artifactId equals the prefix, classifier `cls` |
+
+Because the prefix line is positional (always the line immediately after
+`@groupId`), no sentinel character is needed for it, and empty lines are
+unambiguously artifact lines. Maven groupIds, artifactIds and versions never
+start with `@` or `=`, so the first-character dispatch is unambiguous.
+
+**Indexing:** artifact lines take dictionary indices sequentially in the order
+they appear, starting at 0. The `@`, prefix and `=` lines consume no index.
+
+### Entries section
+
+One line per runtime extension:
+
+```
+<key-index>[<Δ0>,<Δ1>,...,<Δn>]
+```
+
+- `<key-index>` is the **base-36** dictionary index of the runtime extension
+  artifact (absolute).
+- Inside the brackets are the extension's deployment-rooted dependency closure,
+  as base-36 dictionary indices sorted ascending and **delta-encoded**: the
+  first value is the absolute index, each subsequent value is the gap from the
+  previous one. Reconstruct by a running sum.
+- An empty dependency list is `<key-index>[]`.
+
+For example, `1a[0,3,5]` means: key = dictionary entry `Integer.parseInt("1a", 36)`;
+dependencies = dictionary entries at absolute indices `0`, `0+3=3`, `3+5=8`.
+
+## Determinism
+
+The output is reproducible: the dictionary is sorted by
+`(groupId, version, artifactId, classifier, type)`, so index assignment depends
+only on content (not on map iteration order); entries are ordered by their
+runtime key's dictionary index; and dependency indices are ascending.
+Byte-identical output across builds additionally assumes a consistent JDK/zlib
+(the release toolchain), as with any DEFLATE-based artifact.
+
+## Reference implementation
+
+The Java encoder/decoder is
+`io.quarkus.bom.decomposer.maven.platformgen.CpeArtifactsEncoder` in the
+`quarkus-platform-bom-maven-plugin` module:
+
+```java
+Map<ArtifactCoords, List<ArtifactCoords>> map = CpeArtifactsEncoder.decode(value);
+```
+
+Its class Javadoc is the authoritative description of the format.

--- a/integration-tests/platform-generator/pom.xml
+++ b/integration-tests/platform-generator/pom.xml
@@ -38,6 +38,12 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-platform-bom-maven-plugin</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/integration-tests/platform-generator/src/test/java/io/quarkus/platform/generator/PlatformTestProjectGenerator.java
+++ b/integration-tests/platform-generator/src/test/java/io/quarkus/platform/generator/PlatformTestProjectGenerator.java
@@ -4,9 +4,16 @@ import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.maven.project.MavenModuleGenerator;
 import io.quarkus.maven.project.MavenPluginConfigBuilder;
 import io.quarkus.platform.generator.builder.MavenInvokerPlatformTestProjectBuilder;
+import io.quarkus.registry.catalog.Extension;
+import io.quarkus.registry.catalog.ExtensionCatalog;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class PlatformTestProjectGenerator {
@@ -38,6 +45,8 @@ public class PlatformTestProjectGenerator {
         private ArtifactCoords inputBom;
         private ArtifactCoords generatedBom;
         private String cpe;
+        private String offering;
+        private final Map<ArtifactCoords, Map<String, Object>> extensionMetadata = new LinkedHashMap<>();
 
         private PlatformMemberGeneratorConfig(PlatformTestProjectGenerator platformGenerator) {
             this.platformGenerator = Objects.requireNonNull(platformGenerator);
@@ -50,6 +59,18 @@ public class PlatformTestProjectGenerator {
 
         public PlatformMemberGeneratorConfig setCpe(String cpe) {
             this.cpe = cpe;
+            return this;
+        }
+
+        public PlatformMemberGeneratorConfig setOffering(String offering) {
+            this.offering = offering;
+            return this;
+        }
+
+        public PlatformMemberGeneratorConfig addExtensionMetadata(ArtifactCoords extensionCoords, String metadataKey,
+                Object metadataValue) {
+            extensionMetadata.computeIfAbsent(extensionCoords, k -> new LinkedHashMap<>())
+                    .put(metadataKey, metadataValue);
             return this;
         }
 
@@ -175,6 +196,7 @@ public class PlatformTestProjectGenerator {
         configurePlatformGenerator(rootPom.addPomModule(PLATFORM_CONFIG_MODULE));
 
         rootPom.generate(projectDir);
+        generateMetadataOverrideCatalogs();
 
         return MavenInvokerPlatformTestProjectBuilder.getInstance()
                 .setUseDefaultLocalRepositoryAsRemote(true)
@@ -278,7 +300,46 @@ public class PlatformTestProjectGenerator {
         }
 
         if (memberConfig.cpe != null) {
-            member.configure("sbom").configure("productInfo").setParameter("cpe", memberConfig.cpe);
+            var productInfo = member.configure("sbom").configure("productInfo");
+            productInfo.setParameter("cpe", memberConfig.cpe);
+            if (memberConfig.name != null) {
+                productInfo.setParameter("name", memberConfig.name);
+            }
+            if (memberConfig.offering != null) {
+                productInfo.setParameter("offering", memberConfig.offering);
+            }
+        }
+
+        if (!memberConfig.extensionMetadata.isEmpty()) {
+            var catalogFileName = memberConfig.getName().toLowerCase() + "-metadata-overrides.json";
+            var metadataOverrideFiles = member.configure("metadataOverrideFiles");
+            metadataOverrideFiles.setParameter("metadataOverrideFile",
+                    "${project.basedir}/" + catalogFileName);
+        }
+    }
+
+    private void generateMetadataOverrideCatalogs() {
+        for (PlatformMemberGeneratorConfig memberConfig : memberConfigs) {
+            if (memberConfig.extensionMetadata.isEmpty()) {
+                continue;
+            }
+            var catalogFileName = memberConfig.getName().toLowerCase() + "-metadata-overrides.json";
+            var catalogFile = projectDir.resolve(PLATFORM_CONFIG_MODULE).resolve(catalogFileName);
+            var catalogBuilder = ExtensionCatalog.builder();
+            for (var entry : memberConfig.extensionMetadata.entrySet()) {
+                var extBuilder = Extension.builder()
+                        .setArtifact(entry.getKey());
+                for (var metaEntry : entry.getValue().entrySet()) {
+                    extBuilder.setMetadata(metaEntry.getKey(), metaEntry.getValue());
+                }
+                catalogBuilder.addExtension(extBuilder.build());
+            }
+            try {
+                Files.createDirectories(catalogFile.getParent());
+                catalogBuilder.build().persist(catalogFile);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
         }
     }
 }

--- a/integration-tests/platform-generator/src/test/java/io/quarkus/platform/generator/PlatformTestProjectGenerator.java
+++ b/integration-tests/platform-generator/src/test/java/io/quarkus/platform/generator/PlatformTestProjectGenerator.java
@@ -37,6 +37,7 @@ public class PlatformTestProjectGenerator {
         private String name;
         private ArtifactCoords inputBom;
         private ArtifactCoords generatedBom;
+        private String cpe;
 
         private PlatformMemberGeneratorConfig(PlatformTestProjectGenerator platformGenerator) {
             this.platformGenerator = Objects.requireNonNull(platformGenerator);
@@ -44,6 +45,11 @@ public class PlatformTestProjectGenerator {
 
         public PlatformMemberGeneratorConfig setName(String name) {
             this.name = name;
+            return this;
+        }
+
+        public PlatformMemberGeneratorConfig setCpe(String cpe) {
+            this.cpe = cpe;
             return this;
         }
 
@@ -111,6 +117,10 @@ public class PlatformTestProjectGenerator {
                 .setInputBom(inputBom);
         memberConfigs.add(member);
         return member;
+    }
+
+    public PlatformMemberGeneratorConfig configureMember(MavenModuleGenerator inputBom) {
+        return configureMember(ArtifactCoords.pom(inputBom.getGroupId(), inputBom.getArtifactId(), inputBom.getVersion()));
     }
 
     public PlatformTestProjectGenerator addMember(ArtifactCoords inputBom) {
@@ -265,6 +275,10 @@ public class PlatformTestProjectGenerator {
         } else {
             release.setParameter("next",
                     "${platform.groupId}:quarkus-" + memberConfig.inputBom.getArtifactId() + ":${platform.version}");
+        }
+
+        if (memberConfig.cpe != null) {
+            member.configure("sbom").configure("productInfo").setParameter("cpe", memberConfig.cpe);
         }
     }
 }

--- a/integration-tests/platform-generator/src/test/java/io/quarkus/platform/generator/test/MemberCpeArtifactsPropertyTest.java
+++ b/integration-tests/platform-generator/src/test/java/io/quarkus/platform/generator/test/MemberCpeArtifactsPropertyTest.java
@@ -1,0 +1,99 @@
+package io.quarkus.platform.generator.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.quarkus.bom.decomposer.maven.platformgen.CpeArtifactsEncoder;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.platform.generator.PlatformTestProjectGenerator;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class MemberCpeArtifactsPropertyTest {
+
+    private static final String CAMEL_CPE = "cpe:2.3:a:acme:camel_quarkus:1.0:*:*:*:*:*:*:*";
+
+    @TempDir
+    Path workingDir;
+
+    @Test
+    void memberCpeArtifactsPropertyIsGeneratedWhenOfferingIsSet() throws Exception {
+        var platformGenerator = PlatformTestProjectGenerator.newInstance();
+
+        var camelProject = platformGenerator.configureProject("org.camel", "camel-parent", "1.0")
+                .setScm("https://camel.org", "1.0");
+        var camelAtom = camelProject.addQuarkusExtensionRuntimeModule("camel-atom");
+        var camelAtomDeployment = camelProject.addModule("camel-atom-deployment")
+                .addDependency(camelAtom);
+        var camelBom = camelProject.addPomModule("camel-bom")
+                .addVersionConstraint(camelAtom)
+                .addVersionConstraint(camelAtomDeployment);
+
+        platformGenerator.configureMember(camelBom)
+                .setName("Camel")
+                .setCpe(CAMEL_CPE)
+                .setOffering("camel")
+                .addExtensionMetadata(
+                        ArtifactCoords.jar(camelAtom.getGroupId(), camelAtom.getArtifactId(), camelAtom.getVersion()),
+                        "camel-support", true);
+
+        var platform = platformGenerator
+                .setProjectDir(workingDir)
+                .generateProject()
+                .build();
+
+        var camel = platform.getMember("Camel");
+        var cpeArtifactsKey = "platform." + PlatformTestProjectGenerator.DEFAULT_GROUP_ID
+                + ".quarkus-camel-bom.cpe-artifacts";
+
+        assertThat(camel.getProperties()).containsKey(cpeArtifactsKey);
+
+        String encoded = camel.getProperties().getProperty(cpeArtifactsKey);
+        Map<ArtifactCoords, List<ArtifactCoords>> decoded = CpeArtifactsEncoder.decode(encoded);
+        assertThat(decoded).isNotEmpty();
+
+        var keyPrefix = "platform." + PlatformTestProjectGenerator.DEFAULT_GROUP_ID + ".quarkus-camel-bom.";
+        assertThat(camel.getProperties().getProperty(keyPrefix + "product-name")).isEqualTo("Camel");
+
+        // the map is keyed by the runtime extension artifact
+        var runtimeKey = decoded.keySet().stream()
+                .filter(coords -> coords.getArtifactId().equals("camel-atom"))
+                .findFirst()
+                .orElse(null);
+        assertThat(runtimeKey)
+                .as("Decoded map should be keyed by the camel-atom runtime artifact")
+                .isNotNull();
+
+        // the value should contain the corresponding deployment artifact
+        assertThat(decoded.get(runtimeKey).stream()
+                .anyMatch(coords -> coords.getArtifactId().equals("camel-atom-deployment")))
+                        .as("The runtime artifact should map to the camel-atom-deployment artifact")
+                        .isTrue();
+    }
+
+    @Test
+    void memberWithoutOfferingDoesNotGenerateCpeArtifacts() throws Exception {
+        var platformGenerator = PlatformTestProjectGenerator.newInstance();
+
+        var camelProject = platformGenerator.configureProject("org.camel", "camel-parent", "1.0")
+                .setScm("https://camel.org", "1.0");
+        var camelAtom = camelProject.addQuarkusExtensionRuntimeModule("camel-atom");
+        var camelBom = camelProject.addPomModule("camel-bom")
+                .addVersionConstraint(camelAtom);
+
+        platformGenerator.configureMember(camelBom)
+                .setName("Camel")
+                .setCpe(CAMEL_CPE);
+
+        var platform = platformGenerator
+                .setProjectDir(workingDir)
+                .generateProject()
+                .build();
+
+        var camel = platform.getMember("Camel");
+        assertThat(camel.getProperties().stringPropertyNames())
+                .noneMatch(name -> name.endsWith(".cpe-artifacts"));
+    }
+}

--- a/integration-tests/platform-generator/src/test/java/io/quarkus/platform/generator/test/MemberCpePropertyTest.java
+++ b/integration-tests/platform-generator/src/test/java/io/quarkus/platform/generator/test/MemberCpePropertyTest.java
@@ -1,0 +1,52 @@
+package io.quarkus.platform.generator.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.quarkus.platform.generator.PlatformTestProjectGenerator;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class MemberCpePropertyTest {
+
+    private static final String CAMEL_CPE = "cpe:2.3:a:acme:camel_quarkus:1.0:*:*:*:*:*:*:*";
+
+    @TempDir
+    Path workingDir;
+
+    @Test
+    void memberCpeIsExposedAsPlatformProperty() throws Exception {
+        var platformGenerator = PlatformTestProjectGenerator.newInstance();
+
+        var camelProject = platformGenerator.configureProject("org.camel", "camel-parent", "1.0")
+                .setScm("https://camel.org", "1.0");
+        var camelAtom = camelProject.addQuarkusExtensionRuntimeModule("camel-atom");
+        var camelBom = camelProject.addPomModule("camel-bom")
+                .addVersionConstraint(camelAtom);
+
+        var amqProject = platformGenerator.configureProject("org.amq", "amq-parent", "1.0")
+                .setScm("https://amq.org", "1.0");
+        var amqJms = amqProject.addQuarkusExtensionRuntimeModule("amq-jms");
+        var amqBom = amqProject.addPomModule("amq-bom")
+                .addVersionConstraint(amqJms);
+
+        // Camel declares a product CPE, AMQ does not
+        platformGenerator.configureMember(camelBom).setName("Camel").setCpe(CAMEL_CPE);
+        platformGenerator.configureMember(amqBom).setName("AMQ");
+
+        var platform = platformGenerator
+                .setProjectDir(workingDir)
+                .generateProject()
+                .build();
+
+        // The Camel member's own generated properties carry its CPE, keyed by the generated member BOM GA
+        var camel = platform.getMember("Camel");
+        var expectedKey = "platform." + PlatformTestProjectGenerator.DEFAULT_GROUP_ID + ".quarkus-camel-bom.cpe";
+        assertThat(camel.getProperties()).containsEntry(expectedKey, CAMEL_CPE);
+
+        // A member without a configured CPE gets no .cpe property
+        var amq = platform.getMember("AMQ");
+        assertThat(amq.getProperties().stringPropertyNames())
+                .noneMatch(name -> name.endsWith(".cpe"));
+    }
+}

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -166,5 +166,15 @@
             <groupId>io.smallrye.beanbag</groupId>
             <artifactId>smallrye-beanbag-sisu</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/maven-plugin/src/main/java/io/quarkus/bom/decomposer/maven/platformgen/CpeArtifactsEncoder.java
+++ b/maven-plugin/src/main/java/io/quarkus/bom/decomposer/maven/platformgen/CpeArtifactsEncoder.java
@@ -1,0 +1,358 @@
+package io.quarkus.bom.decomposer.maven.platformgen;
+
+import io.quarkus.maven.dependency.ArtifactCoords;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+import java.util.zip.Deflater;
+import java.util.zip.Inflater;
+
+/**
+ * Encodes and decodes the {@code cpe-artifacts} platform property.
+ * <p>
+ * The property records, for each supported runtime extension artifact of a platform member, the set of
+ * artifacts that a consumer (a Quarkus build step) should attribute to that member's CPE. The data is a
+ * map keyed by the <em>runtime</em> extension artifact, so a consumer can look up the runtime artifacts
+ * flagged in the {@code ApplicationModel} directly, without having to map them to their deployment
+ * counterparts itself. The value of each entry is the extension's deployment artifact followed by the
+ * artifacts of its resolved deployment dependency closure (aligned to the versions the platform ships).
+ * <p>
+ * <h2>Serialized format</h2>
+ * The same coordinates recur heavily across entries (deployment closures overlap between extensions), and
+ * even distinct coordinates share groupIds, versions and artifactId prefixes. The map is serialized in two
+ * sections separated by a {@value #SEPARATOR} line:
+ * <ol>
+ * <li>a <em>dictionary</em> of every distinct coordinate, grouped so shared parts are written once;</li>
+ * <li>the <em>entries</em>: one line per runtime extension as {@code <runtime-index>[<delta>,<delta>,...]},
+ * where the runtime index and the (delta-encoded) dependency indices are base-36 references into the
+ * dictionary.</li>
+ * </ol>
+ * <h3>Dictionary section</h3>
+ * Coordinates are grouped by groupId; within a groupId they are grouped by version. Each line is
+ * self-identifying by its first character:
+ * <ul>
+ * <li>{@code @groupId} &mdash; starts a group; the <em>very next line</em> is that group's common
+ * artifactId prefix (possibly empty), applied to every artifact line in the group;</li>
+ * <li>{@code =version} &mdash; starts a version sub-block within the current group;</li>
+ * <li>anything else &mdash; an artifact line: the artifactId with the group prefix stripped, optionally
+ * followed by {@code :classifier} and/or {@code :type}. Trailing defaults (empty classifier, {@code jar}
+ * type) are omitted, so a plain artifactId means an empty-classifier {@code jar}. An <em>empty</em> line
+ * means the artifactId equals the group prefix exactly.</li>
+ * </ul>
+ * Artifact lines take dictionary indices sequentially in the order they appear; the {@code @}/prefix/{@code =}
+ * lines consume no index. The prefix line is positional (always present immediately after {@code @groupId}),
+ * so no sentinel character is needed for it and empty lines are unambiguously artifact lines.
+ * <p>
+ * Removing the long-range repetition this way (which deflate's 32&nbsp;KB window cannot reach) and
+ * delta-encoding the ascending dependency indices shrinks a real platform member's encoded value by roughly
+ * a fifth beyond a naive dictionary.
+ * <p>
+ * The output is <strong>deterministic</strong> and therefore reproducible: the dictionary is sorted by
+ * (groupId, version, artifactId, classifier, type), so index assignment depends only on content (not on the
+ * input map's iteration order); entries are ordered by their runtime key's dictionary index; and dependency
+ * indices are emitted in ascending order. The serialized text is then deflate-compressed and Base64-encoded
+ * to keep the property value compact. Byte-identical output across builds additionally assumes a consistent
+ * JDK/zlib (the release toolchain), as with any deflate-based artifact.
+ */
+public final class CpeArtifactsEncoder {
+
+    /** Line separating the coordinate dictionary from the entry section. Never a valid dictionary line. */
+    static final String SEPARATOR = "--";
+    /** Radix used to encode dictionary indices compactly. */
+    private static final int RADIX = 36;
+
+    /** Total order over coordinates used for the dictionary; distinguishes every distinct coordinate. */
+    private static final Comparator<ArtifactCoords> COORDS_ORDER = Comparator
+            .comparing(ArtifactCoords::getGroupId)
+            .thenComparing(ArtifactCoords::getVersion)
+            .thenComparing(ArtifactCoords::getArtifactId)
+            .thenComparing(ArtifactCoords::getClassifier)
+            .thenComparing(ArtifactCoords::getType);
+
+    private CpeArtifactsEncoder() {
+    }
+
+    public static String encode(Map<ArtifactCoords, List<ArtifactCoords>> deploymentDeps) {
+        if (deploymentDeps.isEmpty()) {
+            return "";
+        }
+        String text = serialize(deploymentDeps);
+        byte[] compressed = deflate(text.getBytes(StandardCharsets.UTF_8));
+        return Base64.getEncoder().encodeToString(compressed);
+    }
+
+    public static Map<ArtifactCoords, List<ArtifactCoords>> decode(String encoded) {
+        if (encoded == null || encoded.isEmpty()) {
+            return Map.of();
+        }
+        byte[] compressed = Base64.getDecoder().decode(encoded);
+        byte[] raw = inflate(compressed);
+        String text = new String(raw, StandardCharsets.UTF_8);
+        return deserialize(text);
+    }
+
+    static String serialize(Map<ArtifactCoords, List<ArtifactCoords>> deploymentDeps) {
+        // Distinct coordinates, ordered deterministically so index assignment depends only on content.
+        // The runtime key need not be added explicitly: by Quarkus extension convention a deployment
+        // artifact depends on its runtime artifact, so every key appears in its own dependency closure.
+        var distinct = new TreeSet<ArtifactCoords>(COORDS_ORDER);
+        int depOccurrences = 0;
+        for (var entry : deploymentDeps.entrySet()) {
+            for (ArtifactCoords dep : entry.getValue()) {
+                distinct.add(dep);
+                depOccurrences++;
+            }
+        }
+
+        var dictionary = new ArrayList<>(distinct);
+        var index = new HashMap<ArtifactCoords, Integer>(dictionary.size());
+        for (int i = 0; i < dictionary.size(); i++) {
+            index.put(dictionary.get(i), i);
+        }
+
+        var sb = new StringBuilder(dictionary.size() * 16 + depOccurrences * 4 + 64);
+
+        // Dictionary section: grouped by groupId, then by version, factoring out the common artifactId prefix.
+        int n = dictionary.size();
+        int i = 0;
+        while (i < n) {
+            String groupId = dictionary.get(i).getGroupId();
+            int groupEnd = i;
+            while (groupEnd < n && dictionary.get(groupEnd).getGroupId().equals(groupId)) {
+                groupEnd++;
+            }
+            String prefix = commonArtifactIdPrefix(dictionary, i, groupEnd);
+            sb.append('@').append(groupId).append('\n');
+            sb.append(prefix).append('\n'); // positional prefix line, empty when there is no shared prefix
+            String version = null;
+            for (int k = i; k < groupEnd; k++) {
+                ArtifactCoords c = dictionary.get(k);
+                if (!c.getVersion().equals(version)) {
+                    version = c.getVersion();
+                    sb.append('=').append(version).append('\n');
+                }
+                appendRemainder(sb, c, prefix.length());
+                sb.append('\n');
+            }
+            i = groupEnd;
+        }
+        sb.append(SEPARATOR).append('\n');
+
+        // Entries: ordered by the key's dictionary index; dependency indices sorted ascending, then
+        // delta-encoded (first index absolute, the rest as gaps) to keep the numbers small.
+        var entries = new ArrayList<>(deploymentDeps.entrySet());
+        entries.sort(Comparator.comparingInt(e -> index.get(e.getKey())));
+        for (var entry : entries) {
+            sb.append(Integer.toString(index.get(entry.getKey()), RADIX));
+            sb.append('[');
+            int[] depIndices = entry.getValue().stream().mapToInt(index::get).sorted().toArray();
+            int prev = 0;
+            for (int j = 0; j < depIndices.length; j++) {
+                if (j > 0) {
+                    sb.append(',');
+                }
+                sb.append(Integer.toString(depIndices[j] - prev, RADIX));
+                prev = depIndices[j];
+            }
+            sb.append(']').append('\n');
+        }
+        return sb.toString();
+    }
+
+    static Map<ArtifactCoords, List<ArtifactCoords>> deserialize(String text) {
+        String[] lines = text.split("\n", -1);
+
+        // Section 1: the coordinate dictionary, up to the separator line. Empty lines are significant here
+        // (an empty prefix line, or an artifact whose id equals the prefix), so blanks are not skipped.
+        var dictionary = new ArrayList<ArtifactCoords>();
+        int i = 0;
+        boolean separatorSeen = false;
+        String groupId = null;
+        String prefix = "";
+        String version = null;
+        boolean awaitingPrefix = false;
+        for (; i < lines.length; i++) {
+            String line = lines[i];
+            if (line.equals(SEPARATOR)) {
+                separatorSeen = true;
+                i++;
+                break;
+            }
+            if (awaitingPrefix) {
+                prefix = line;
+                awaitingPrefix = false;
+                continue;
+            }
+            if (!line.isEmpty() && line.charAt(0) == '@') {
+                groupId = line.substring(1);
+                prefix = "";
+                version = null;
+                awaitingPrefix = true;
+                continue;
+            }
+            if (!line.isEmpty() && line.charAt(0) == '=') {
+                version = line.substring(1);
+                continue;
+            }
+            // Artifact line (possibly empty, meaning the artifactId equals the prefix).
+            if (groupId == null || version == null) {
+                throw new IllegalArgumentException("Invalid format: artifact before group/version: '" + line + "'");
+            }
+            dictionary.add(parseArtifact(groupId, prefix, version, line));
+        }
+        if (!separatorSeen) {
+            throw new IllegalArgumentException("Invalid format: missing '" + SEPARATOR + "' separator");
+        }
+
+        // Section 2: the entries, referencing the dictionary by index (dependency indices delta-encoded).
+        var result = new LinkedHashMap<ArtifactCoords, List<ArtifactCoords>>();
+        for (; i < lines.length; i++) {
+            String line = lines[i];
+            if (line.isEmpty()) {
+                continue;
+            }
+            int bracketOpen = line.indexOf('[');
+            if (bracketOpen < 0 || !line.endsWith("]")) {
+                throw new IllegalArgumentException("Invalid format: " + line);
+            }
+            var deploymentCoords = dictionary.get(parseIndex(line.substring(0, bracketOpen), dictionary));
+            String depsStr = line.substring(bracketOpen + 1, line.length() - 1);
+            List<ArtifactCoords> deps;
+            if (depsStr.isEmpty()) {
+                deps = List.of();
+            } else {
+                var parts = depsStr.split(",");
+                deps = new ArrayList<>(parts.length);
+                int running = 0;
+                for (String part : parts) {
+                    running += parseRadix(part);
+                    deps.add(dictionary.get(checkIndex(running, dictionary)));
+                }
+            }
+            result.put(deploymentCoords, deps);
+        }
+        return result;
+    }
+
+    /** Longest common prefix of the artifactIds in {@code dictionary[from, to)}. */
+    private static String commonArtifactIdPrefix(List<ArtifactCoords> dictionary, int from, int to) {
+        String prefix = dictionary.get(from).getArtifactId();
+        for (int k = from + 1; k < to && !prefix.isEmpty(); k++) {
+            String artifactId = dictionary.get(k).getArtifactId();
+            int max = Math.min(prefix.length(), artifactId.length());
+            int p = 0;
+            while (p < max && prefix.charAt(p) == artifactId.charAt(p)) {
+                p++;
+            }
+            prefix = prefix.substring(0, p);
+        }
+        return prefix;
+    }
+
+    /** Appends an artifact line: the artifactId beyond {@code prefixLen}, with trailing default parts omitted. */
+    private static void appendRemainder(StringBuilder sb, ArtifactCoords c, int prefixLen) {
+        String artifactId = c.getArtifactId();
+        sb.append(artifactId, prefixLen, artifactId.length());
+        String classifier = c.getClassifier();
+        String type = c.getType();
+        boolean jar = ArtifactCoords.TYPE_JAR.equals(type);
+        if (classifier.isEmpty() && jar) {
+            return;
+        }
+        if (jar) {
+            sb.append(':').append(classifier);
+        } else if (classifier.isEmpty()) {
+            sb.append("::").append(type);
+        } else {
+            sb.append(':').append(classifier).append(':').append(type);
+        }
+    }
+
+    private static ArtifactCoords parseArtifact(String groupId, String prefix, String version, String line) {
+        String[] parts = line.split(":", -1);
+        String artifactId = prefix + parts[0];
+        String classifier;
+        String type;
+        switch (parts.length) {
+            case 1:
+                classifier = ArtifactCoords.DEFAULT_CLASSIFIER;
+                type = ArtifactCoords.TYPE_JAR;
+                break;
+            case 2:
+                classifier = parts[1];
+                type = ArtifactCoords.TYPE_JAR;
+                break;
+            case 3:
+                classifier = parts[1];
+                type = parts[2];
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid artifact entry: " + line);
+        }
+        return ArtifactCoords.of(groupId, artifactId, classifier, type, version);
+    }
+
+    private static int parseIndex(String token, List<ArtifactCoords> dictionary) {
+        return checkIndex(parseRadix(token), dictionary);
+    }
+
+    private static int parseRadix(String token) {
+        try {
+            return Integer.parseInt(token, RADIX);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid base-" + RADIX + " token: " + token, e);
+        }
+    }
+
+    private static int checkIndex(int idx, List<ArtifactCoords> dictionary) {
+        if (idx < 0 || idx >= dictionary.size()) {
+            throw new IllegalArgumentException("Dictionary index out of range: " + idx);
+        }
+        return idx;
+    }
+
+    private static byte[] deflate(byte[] input) {
+        var deflater = new Deflater(Deflater.BEST_COMPRESSION);
+        try {
+            deflater.setInput(input);
+            deflater.finish();
+            var out = new ByteArrayOutputStream(input.length);
+            var buf = new byte[1024];
+            while (!deflater.finished()) {
+                int count = deflater.deflate(buf);
+                out.write(buf, 0, count);
+            }
+            return out.toByteArray();
+        } finally {
+            deflater.end();
+        }
+    }
+
+    private static byte[] inflate(byte[] input) {
+        var inflater = new Inflater();
+        try {
+            inflater.setInput(input);
+            var out = new ByteArrayOutputStream(input.length * 4);
+            var buf = new byte[1024];
+            while (!inflater.finished()) {
+                if (inflater.needsInput() || inflater.needsDictionary()) {
+                    throw new IllegalArgumentException("Truncated or corrupt cpe-artifacts data");
+                }
+                int count = inflater.inflate(buf);
+                out.write(buf, 0, count);
+            }
+            return out.toByteArray();
+        } catch (java.util.zip.DataFormatException e) {
+            throw new IllegalArgumentException("Failed to inflate cpe-artifacts data", e);
+        } finally {
+            inflater.end();
+        }
+    }
+}

--- a/maven-plugin/src/main/java/io/quarkus/bom/decomposer/maven/platformgen/GeneratePlatformProjectMojo.java
+++ b/maven-plugin/src/main/java/io/quarkus/bom/decomposer/maven/platformgen/GeneratePlatformProjectMojo.java
@@ -3034,6 +3034,17 @@ public class GeneratePlatformProjectMojo extends AbstractMojo {
                     buf.toString());
         }
 
+        // Expose the member product CPE (if configured) as a platform property keyed by the
+        // generated member BOM coordinates, so consumers (e.g. the SBOM generator) can resolve it.
+        final SbomConfig.ProductConfig productConfig = getProductConfig(member);
+        if (productConfig != null && productConfig.getCpe() != null) {
+            final var memberBom = member.getGeneratedPlatformBom();
+            props.setProperty(
+                    BootstrapConstants.PLATFORM_PROPERTY_PREFIX + memberBom.getGroupId() + "."
+                            + memberBom.getArtifactId() + ".cpe",
+                    productConfig.getCpe());
+        }
+
         if (member.config().isHidden()) {
             Utils.skipInstallAndDeploy(pom);
         }

--- a/maven-plugin/src/main/java/io/quarkus/bom/decomposer/maven/platformgen/GeneratePlatformProjectMojo.java
+++ b/maven-plugin/src/main/java/io/quarkus/bom/decomposer/maven/platformgen/GeneratePlatformProjectMojo.java
@@ -72,6 +72,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -247,6 +248,9 @@ public class GeneratePlatformProjectMojo extends AbstractMojo {
     private final Map<String, String> pomPropsByValues = new HashMap<>();
 
     private List<Profile> generatedBomReleaseProfile;
+
+    private final Map<ArtifactKey, ResolvedExtensionInfo> resolvedExtensionInfoCache = new HashMap<>();
+    private final Map<PlatformMemberConfig, List<ExtensionCatalog>> memberMetadataCatalogsCache = new HashMap<>();
 
     private boolean isClean() {
         final List<String> goals;
@@ -530,41 +534,15 @@ public class GeneratePlatformProjectMojo extends AbstractMojo {
 
             Set<ArtifactKey> selectedKeys = Set.of();
             if (sbomConfig != null && sbomConfig.isSupportedExtensionsOnly()) {
-                List<Path> metadataOverrides = new ArrayList<>();
-                for (String s : member.config().getMetadataOverrideFiles()) {
-                    metadataOverrides.add(Path.of(s));
-                }
-                for (String s : member.config().getMetadataOverrideArtifacts()) {
-                    try {
-                        metadataOverrides
-                                .add(getNonWorkspaceResolver().resolve(toAetherArtifact(s)).getArtifact().getFile().toPath());
-                    } catch (BootstrapMavenException e) {
-                        throw new MojoExecutionException("Failed to resolve " + s, e);
-                    }
-                }
-                if (metadataOverrides.isEmpty()) {
+                var catalogs = loadMetadataOverrideCatalogs(member.config());
+                if (catalogs.isEmpty()) {
                     throw new IllegalStateException("The SBOM generator for member " + member.config().getName()
                             + " is configured to include only supported extensions but no support metadata override sources were provided");
                 }
                 if (extensionSupportPatterns == null) {
                     extensionSupportPatterns = compilePatterns(dominoBuildExtensionSupportPatterns);
                 }
-                selectedKeys = new HashSet<>(metadataOverrides.size());
-                for (Path p : metadataOverrides) {
-                    try {
-                        ExtensionCatalog c = ExtensionCatalog.fromFile(p);
-                        for (var e : c.getExtensions()) {
-                            if (isMatchesDominoBuildPattern(e, extensionSupportPatterns)) {
-                                var key = e.getArtifact().getKey();
-                                selectedKeys.add(key);
-                                selectedKeys.add(ArtifactKey.of(key.getGroupId(), key.getArtifactId() + "-deployment",
-                                        key.getClassifier(), key.getType()));
-                            }
-                        }
-                    } catch (IOException e) {
-                        throw new MojoExecutionException("Failed to deserialize " + p, e);
-                    }
-                }
+                selectedKeys = selectExtensionKeys(catalogs, extensionSupportPatterns);
             }
             for (ProjectRelease r : member.getAlignedDecomposedBom().releases()) {
                 for (ProjectDependency d : r.dependencies()) {
@@ -623,38 +601,12 @@ public class GeneratePlatformProjectMojo extends AbstractMojo {
             final List<ArtifactCoordsPattern> excludePatterns = ArtifactCoordsPattern
                     .toPatterns(dominoConfig.getExcludePatterns());
 
-            List<Path> metadataOverrides = new ArrayList<>();
-            for (String s : member.config().getMetadataOverrideFiles()) {
-                metadataOverrides.add(Path.of(s));
-            }
-            for (String s : member.config().getMetadataOverrideArtifacts()) {
-                try {
-                    metadataOverrides
-                            .add(getNonWorkspaceResolver().resolve(toAetherArtifact(s)).getArtifact().getFile().toPath());
-                } catch (BootstrapMavenException e) {
-                    throw new MojoExecutionException("Failed to resolve " + s, e);
-                }
-            }
-            if (metadataOverrides.isEmpty()) {
+            var catalogs = loadMetadataOverrideCatalogs(member.config());
+            if (catalogs.isEmpty()) {
                 throw new IllegalStateException("The SBOM generator for member " + member.config().getName()
                         + " is configured to include only supported extensions but no support metadata override sources were provided");
             }
-            final Set<ArtifactKey> selectedKeys = new HashSet<>(metadataOverrides.size());
-            for (Path p : metadataOverrides) {
-                try {
-                    ExtensionCatalog c = ExtensionCatalog.fromFile(p);
-                    for (var e : c.getExtensions()) {
-                        if (isMatchesDominoBuildPattern(e, supportPatterns)) {
-                            var key = e.getArtifact().getKey();
-                            selectedKeys.add(key);
-                            selectedKeys.add(ArtifactKey.of(key.getGroupId(), key.getArtifactId() + "-deployment",
-                                    key.getClassifier(), key.getType()));
-                        }
-                    }
-                } catch (IOException e) {
-                    throw new MojoExecutionException("Failed to deserialize " + p, e);
-                }
-            }
+            final Set<ArtifactKey> selectedKeys = selectExtensionKeys(catalogs, supportPatterns);
 
             for (ProjectRelease r : member.getAlignedDecomposedBom().releases()) {
                 for (ProjectDependency d : r.dependencies()) {
@@ -687,57 +639,22 @@ public class GeneratePlatformProjectMojo extends AbstractMojo {
     }
 
     private void addExtensionArtifacts(Artifact a, ProjectDependencyConfig.Mutable dominoConfig) {
-        final Artifact resolved;
-        final boolean relocated;
-        if (a.getFile() == null) {
-            var resolver = getNonWorkspaceResolver();
-            // this trick is done to capture relocations, i.e. when {@code a} was relocated to another artifact
-            var request = new DependencyRequest()
-                    .setCollectRequest(new CollectRequest()
-                            .setRootArtifact(a)
-                            .setDependencies(List.of(new org.eclipse.aether.graph.Dependency(a, JavaScopes.COMPILE, false,
-                                    List.of(new org.eclipse.aether.graph.Exclusion("*", "*", "*", "*")))))
-                            .setRepositories(resolver.getRepositories()));
-            List<DependencyNode> resolvedDeps;
-            try {
-                resolvedDeps = resolver.getSystem().resolveDependencies(resolver.getSession(), request).getRoot().getChildren();
-            } catch (DependencyResolutionException e) {
-                throw new RuntimeException("Failed to resolve " + a, e);
-            }
-            if (resolvedDeps.size() != 1) {
-                throw new IllegalStateException("Expected a single dependency but got " + resolvedDeps);
-            }
-            var node = resolvedDeps.get(0);
-            resolved = node.getArtifact();
-            relocated = !node.getRelocations().isEmpty();
-        } else {
-            resolved = a;
-            relocated = false;
+        var info = resolveExtension(a);
+        if (!info.isExtension) {
+            return;
         }
-        PathTree.ofArchive(resolved.getFile().toPath()).accept(BootstrapConstants.DESCRIPTOR_PATH, visit -> {
-            if (visit != null) {
-                var props = new Properties();
-                try (BufferedReader reader = Files.newBufferedReader(visit.getPath())) {
-                    props.load(reader);
-                } catch (IOException e) {
-                    throw new UncheckedIOException(e);
-                }
-                if (relocated) {
-                    dominoConfig.addProjectArtifacts(ArtifactCoords.of(a.getGroupId(),
-                            a.getArtifactId(), a.getClassifier(), a.getExtension(), a.getVersion()));
-                }
-                dominoConfig.addProjectArtifacts(ArtifactCoords.of(resolved.getGroupId(),
-                        resolved.getArtifactId(), resolved.getClassifier(),
-                        resolved.getExtension(), resolved.getVersion()));
-                var deploymentArtifact = props.getProperty(BootstrapConstants.PROP_DEPLOYMENT_ARTIFACT);
-                if (deploymentArtifact == null) {
-                    getLog().warn("Failed to identify the deployment artifact for " + resolved + " in "
-                            + visit.getUrl());
-                } else {
-                    dominoConfig.addProjectArtifacts(ArtifactCoords.fromString(deploymentArtifact));
-                }
-            }
-        });
+        if (info.relocated) {
+            dominoConfig.addProjectArtifacts(ArtifactCoords.of(a.getGroupId(),
+                    a.getArtifactId(), a.getClassifier(), a.getExtension(), a.getVersion()));
+        }
+        dominoConfig.addProjectArtifacts(ArtifactCoords.of(info.resolved.getGroupId(),
+                info.resolved.getArtifactId(), info.resolved.getClassifier(),
+                info.resolved.getExtension(), info.resolved.getVersion()));
+        if (info.deploymentArtifactCoords == null) {
+            getLog().warn("Failed to identify the deployment artifact for " + info.resolved);
+        } else {
+            dominoConfig.addProjectArtifacts(ArtifactCoords.fromString(info.deploymentArtifactCoords));
+        }
     }
 
     private static boolean isExtensionCandidate(Artifact a, Collection<String> extensionGroupIds,
@@ -756,6 +673,101 @@ public class GeneratePlatformProjectMojo extends AbstractMojo {
             }
         }
         return true;
+    }
+
+    private ResolvedExtensionInfo resolveExtension(Artifact a) {
+        var key = ArtifactKey.of(a.getGroupId(), a.getArtifactId(), a.getClassifier(), a.getExtension());
+        var cached = resolvedExtensionInfoCache.get(key);
+        if (cached != null) {
+            return cached;
+        }
+        final Artifact resolved;
+        final boolean relocated;
+        if (a.getFile() == null) {
+            var resolver = getNonWorkspaceResolver();
+            var request = new DependencyRequest()
+                    .setCollectRequest(new CollectRequest()
+                            .setRootArtifact(a)
+                            .setDependencies(List.of(new org.eclipse.aether.graph.Dependency(a, JavaScopes.COMPILE, false,
+                                    List.of(new org.eclipse.aether.graph.Exclusion("*", "*", "*", "*")))))
+                            .setRepositories(resolver.getRepositories()));
+            List<DependencyNode> resolvedDeps;
+            try {
+                resolvedDeps = resolver.getSystem().resolveDependencies(resolver.getSession(), request).getRoot()
+                        .getChildren();
+            } catch (DependencyResolutionException e) {
+                throw new RuntimeException("Failed to resolve " + a, e);
+            }
+            if (resolvedDeps.size() != 1) {
+                throw new IllegalStateException("Expected a single dependency but got " + resolvedDeps);
+            }
+            var node = resolvedDeps.get(0);
+            resolved = node.getArtifact();
+            relocated = !node.getRelocations().isEmpty();
+        } else {
+            resolved = a;
+            relocated = false;
+        }
+        final String[] deploymentCoords = { null };
+        final boolean[] hasDescriptor = { false };
+        PathTree.ofArchive(resolved.getFile().toPath()).accept(BootstrapConstants.DESCRIPTOR_PATH, visit -> {
+            if (visit != null) {
+                hasDescriptor[0] = true;
+                var props = new Properties();
+                try (BufferedReader reader = Files.newBufferedReader(visit.getPath())) {
+                    props.load(reader);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+                deploymentCoords[0] = props.getProperty(BootstrapConstants.PROP_DEPLOYMENT_ARTIFACT);
+            }
+        });
+        var info = new ResolvedExtensionInfo(resolved, relocated, hasDescriptor[0], deploymentCoords[0]);
+        resolvedExtensionInfoCache.put(key, info);
+        return info;
+    }
+
+    private List<ExtensionCatalog> loadMetadataOverrideCatalogs(PlatformMemberConfig memberConfig)
+            throws MojoExecutionException {
+        var cached = memberMetadataCatalogsCache.get(memberConfig);
+        if (cached != null) {
+            return cached;
+        }
+        List<ExtensionCatalog> catalogs = new ArrayList<>();
+        for (String s : memberConfig.getMetadataOverrideFiles()) {
+            try {
+                catalogs.add(ExtensionCatalog.fromFile(Path.of(s)));
+            } catch (IOException e) {
+                throw new MojoExecutionException("Failed to deserialize " + s, e);
+            }
+        }
+        for (String s : memberConfig.getMetadataOverrideArtifacts()) {
+            try {
+                var path = getNonWorkspaceResolver().resolve(toAetherArtifact(s)).getArtifact().getFile().toPath();
+                catalogs.add(ExtensionCatalog.fromFile(path));
+            } catch (BootstrapMavenException e) {
+                throw new MojoExecutionException("Failed to resolve " + s, e);
+            } catch (IOException e) {
+                throw new MojoExecutionException("Failed to deserialize " + s, e);
+            }
+        }
+        memberMetadataCatalogsCache.put(memberConfig, catalogs);
+        return catalogs;
+    }
+
+    private static Set<ArtifactKey> selectExtensionKeys(List<ExtensionCatalog> catalogs, List<Pattern> patterns) {
+        final Set<ArtifactKey> selectedKeys = new HashSet<>();
+        for (ExtensionCatalog c : catalogs) {
+            for (var e : c.getExtensions()) {
+                if (isMatchesDominoBuildPattern(e, patterns)) {
+                    var key = e.getArtifact().getKey();
+                    selectedKeys.add(key);
+                    selectedKeys.add(ArtifactKey.of(key.getGroupId(), key.getArtifactId() + "-deployment",
+                            key.getClassifier(), key.getType()));
+                }
+            }
+        }
+        return selectedKeys;
     }
 
     private void generateExtensionChangesModule(Model parentPom) throws MojoExecutionException {
@@ -923,7 +935,9 @@ public class GeneratePlatformProjectMojo extends AbstractMojo {
                     if (productConfig.getStream() != null) {
                         productInfoDom.addChild(textDomElement("stream", productConfig.getStream()));
                     }
-                    productInfoDom.addChild(textDomElement("type", productConfig.getType().toUpperCase()));
+                    if (productConfig.getType() != null) {
+                        productInfoDom.addChild(textDomElement("type", productConfig.getType().toUpperCase()));
+                    }
                     productInfoDom.addChild(textDomElement("group", productConfig.getGroup()));
                     productInfoDom.addChild(textDomElement("name", productConfig.getName()));
                     productInfoDom.addChild(textDomElement("version", productConfig.getVersion()));
@@ -1043,6 +1057,124 @@ public class GeneratePlatformProjectMojo extends AbstractMojo {
             productConfig.setVersion(member.getGeneratedPlatformBom().getVersion());
         }
         return productConfig;
+    }
+
+    /**
+     * Collects the artifacts that should be attributed to a platform member's CPE, keyed by the member's
+     * supported runtime extension artifacts.
+     * <p>
+     * For every extension of the member that is flagged as supported for the given offering, the extension's
+     * deployment dependency closure is resolved with the platform-aligned constraints enforced (the core
+     * constraints for the core member, the core plus the member's own constraints otherwise). The resulting
+     * map is keyed by the runtime extension artifact and its value holds the deployment artifact together
+     * with its resolved transitive dependencies, so a consumer can attribute those to the member's CPE by
+     * looking up the runtime artifacts it finds in the {@code ApplicationModel}.
+     *
+     * @param member the platform member whose CPE artifacts are collected
+     * @param offering the offering the extensions must be supported for
+     * @return a map from each supported runtime extension artifact to its deployment closure
+     */
+    private Map<ArtifactCoords, List<ArtifactCoords>> collectCpeArtifacts(PlatformMemberImpl member, String offering)
+            throws MojoExecutionException {
+        final Map<ArtifactCoords, List<ArtifactCoords>> result = new LinkedHashMap<>();
+
+        final List<ExtensionCatalog> catalogs = loadMetadataOverrideCatalogs(member.config());
+        if (catalogs.isEmpty()) {
+            getLog().warn("No metadata override catalogs found for member " + member.config().getName()
+                    + ", skipping CPE artifacts collection");
+            return result;
+        }
+        final Set<ArtifactKey> offeringKeys = selectExtensionKeys(catalogs,
+                compilePatterns(List.of(offering + "-support")));
+        if (offeringKeys.isEmpty()) {
+            return result;
+        }
+
+        final var resolver = getNonWorkspaceResolver();
+        final List<org.eclipse.aether.graph.Dependency> enforcedConstraints = getEnforcedConstraints(member);
+        for (ProjectRelease r : member.getAlignedDecomposedBom().releases()) {
+            for (ProjectDependency d : r.dependencies()) {
+                final Artifact a = d.artifact();
+                if (!offeringKeys.contains(d.key())
+                        || !isExtensionCandidate(a, member.config().getExtensionGroupIds(), List.of())) {
+                    continue;
+                }
+                var info = resolveExtension(a);
+                if (!info.isExtension || info.deploymentArtifactCoords == null) {
+                    continue;
+                }
+                // key the map by the runtime extension artifact so the consumer can look it up directly
+                // against the runtime artifacts flagged in the ApplicationModel, without having to map
+                // runtime artifacts to their deployment counterparts itself
+                final Artifact runtime = info.resolved;
+                final ArtifactCoords runtimeCoords = ArtifactCoords.of(runtime.getGroupId(), runtime.getArtifactId(),
+                        runtime.getClassifier(), runtime.getExtension(), runtime.getVersion());
+                var deploymentCoords = ArtifactCoords.fromString(info.deploymentArtifactCoords);
+                try {
+                    var aetherArtifact = new DefaultArtifact(deploymentCoords.getGroupId(),
+                            deploymentCoords.getArtifactId(), deploymentCoords.getClassifier(),
+                            deploymentCoords.getType(), deploymentCoords.getVersion());
+                    // Add the deployment artifact as a direct dependency rather than the root so that
+                    // its own dependencies are scope-filtered by the session's ScopeDependencySelector
+                    // (which does not filter the root's direct dependencies).
+                    var collectRequest = new CollectRequest()
+                            .setDependencies(List.of(
+                                    new org.eclipse.aether.graph.Dependency(aetherArtifact, JavaScopes.COMPILE)))
+                            .setManagedDependencies(enforcedConstraints)
+                            .setRepositories(resolver.getRepositories());
+                    var collectResult = resolver.getSystem().collectDependencies(resolver.getSession(), collectRequest);
+
+                    // the value is the deployment artifact itself plus its transitive closure
+                    final DependencyNode deploymentNode = collectResult.getRoot().getChildren().get(0);
+                    Set<ArtifactCoords> deps = new LinkedHashSet<>();
+                    deps.add(deploymentCoords);
+                    collectCpeTransitiveDeps(deploymentNode, deps);
+                    result.put(runtimeCoords, new ArrayList<>(deps));
+                } catch (DependencyCollectionException e) {
+                    throw new MojoExecutionException(
+                            "Failed to collect the dependencies of the supported extension deployment artifact "
+                                    + deploymentCoords,
+                            e);
+                }
+            }
+        }
+        return result;
+    }
+
+    private static void collectCpeTransitiveDeps(DependencyNode node, Set<ArtifactCoords> deps) {
+        for (DependencyNode child : node.getChildren()) {
+            var a = child.getArtifact();
+            var coords = ArtifactCoords.of(a.getGroupId(), a.getArtifactId(),
+                    a.getClassifier(), a.getExtension(), a.getVersion());
+            // skip nodes already visited to avoid duplicates and re-walking shared subtrees
+            if (deps.add(coords)) {
+                collectCpeTransitiveDeps(child, deps);
+            }
+        }
+    }
+
+    /**
+     * Returns the managed dependencies (aligned to the versions the platform ships) that should be
+     * enforced when resolving a member's deployment dependency closures. For the core member only the
+     * core constraints are enforced; for every other member the core constraints plus the member's own
+     * constraints are enforced.
+     */
+    private List<org.eclipse.aether.graph.Dependency> getEnforcedConstraints(PlatformMemberImpl member) {
+        final List<org.eclipse.aether.graph.Dependency> managed = new ArrayList<>();
+        addAlignedConstraints(quarkusCore, managed);
+        if (member != quarkusCore) {
+            addAlignedConstraints(member, managed);
+        }
+        return managed;
+    }
+
+    private static void addAlignedConstraints(PlatformMemberImpl member,
+            List<org.eclipse.aether.graph.Dependency> managed) {
+        for (ProjectRelease r : member.getAlignedDecomposedBom().releases()) {
+            for (ProjectDependency d : r.dependencies()) {
+                managed.add(d.dependency());
+            }
+        }
     }
 
     private ProjectDependencyFilterConfig effectiveMemberDepsToBuildConfig(PlatformMemberConfig member) {
@@ -3039,10 +3171,29 @@ public class GeneratePlatformProjectMojo extends AbstractMojo {
         final SbomConfig.ProductConfig productConfig = getProductConfig(member);
         if (productConfig != null && productConfig.getCpe() != null) {
             final var memberBom = member.getGeneratedPlatformBom();
-            props.setProperty(
-                    BootstrapConstants.PLATFORM_PROPERTY_PREFIX + memberBom.getGroupId() + "."
-                            + memberBom.getArtifactId() + ".cpe",
-                    productConfig.getCpe());
+            final String memberKeyPrefix = BootstrapConstants.PLATFORM_PROPERTY_PREFIX
+                    + memberBom.getGroupId() + "." + memberBom.getArtifactId() + ".";
+            props.setProperty(memberKeyPrefix + "cpe", productConfig.getCpe());
+            if (!memberBom.getArtifactId().equals(productConfig.getName())) {
+                setIfNotBlank(props, memberKeyPrefix + "product-name", productConfig.getName());
+            }
+            if (!memberBom.getVersion().equals(productConfig.getVersion())) {
+                setIfNotBlank(props, memberKeyPrefix + "product-version", productConfig.getVersion());
+            }
+            if (!"framework".equalsIgnoreCase(productConfig.getType())) {
+                setIfNotBlank(props, memberKeyPrefix + "product-type", productConfig.getType());
+            }
+            setIfNotBlank(props, memberKeyPrefix + "product-purl", productConfig.getPurl());
+            setIfNotBlank(props, memberKeyPrefix + "product-description", productConfig.getDescription());
+
+            if (productConfig.getOffering() != null) {
+                final Map<ArtifactCoords, List<ArtifactCoords>> deploymentDeps = collectCpeArtifacts(member,
+                        productConfig.getOffering());
+                if (!deploymentDeps.isEmpty()) {
+                    props.setProperty(memberKeyPrefix + "cpe-artifacts",
+                            CpeArtifactsEncoder.encode(deploymentDeps));
+                }
+            }
         }
 
         if (member.config().isHidden()) {
@@ -3242,6 +3393,21 @@ public class GeneratePlatformProjectMojo extends AbstractMojo {
             platformReleaseConfig = tmp;
         }
         return platformReleaseConfig;
+    }
+
+    private static class ResolvedExtensionInfo {
+        final Artifact resolved;
+        final boolean relocated;
+        final boolean isExtension;
+        final String deploymentArtifactCoords;
+
+        ResolvedExtensionInfo(Artifact resolved, boolean relocated, boolean isExtension,
+                String deploymentArtifactCoords) {
+            this.resolved = resolved;
+            this.relocated = relocated;
+            this.isExtension = isExtension;
+            this.deploymentArtifactCoords = deploymentArtifactCoords;
+        }
     }
 
     private class PlatformMemberImpl implements PlatformMember {
@@ -3547,6 +3713,12 @@ public class GeneratePlatformProjectMojo extends AbstractMojo {
 
     private static boolean isBlank(String s) {
         return s == null || s.isBlank();
+    }
+
+    private static void setIfNotBlank(OrderedProperties props, String key, String value) {
+        if (!isBlank(value)) {
+            props.setProperty(key, value);
+        }
     }
 
     private static Path deleteAndCreateDir(Path dir) throws MojoExecutionException {

--- a/maven-plugin/src/test/java/io/quarkus/bom/decomposer/maven/platformgen/CpeArtifactsEncoderTest.java
+++ b/maven-plugin/src/test/java/io/quarkus/bom/decomposer/maven/platformgen/CpeArtifactsEncoderTest.java
@@ -1,0 +1,215 @@
+package io.quarkus.bom.decomposer.maven.platformgen;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.quarkus.maven.dependency.ArtifactCoords;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import org.junit.jupiter.api.Test;
+
+class CpeArtifactsEncoderTest {
+
+    @Test
+    void roundTripsRuntimeKeyedClosure() {
+        // By convention the deployment closure contains the runtime artifact, so the key appears in its value.
+        ArtifactCoords rt = ArtifactCoords.jar("org.acme", "acme-core", "1.0");
+        ArtifactCoords deployment = ArtifactCoords.jar("org.acme", "acme-core-deployment", "1.0");
+        ArtifactCoords quarkusCore = ArtifactCoords.jar("io.quarkus", "quarkus-core", "3.15.0");
+
+        String encoded = CpeArtifactsEncoder.encode(Map.of(rt, List.of(rt, deployment, quarkusCore)));
+        Map<ArtifactCoords, List<ArtifactCoords>> decoded = CpeArtifactsEncoder.decode(encoded);
+
+        assertThat(decoded).containsOnlyKeys(rt);
+        assertThat(decoded.get(rt)).containsExactlyInAnyOrder(rt, deployment, quarkusCore);
+    }
+
+    @Test
+    void roundTripsSharedDependenciesAcrossEntries() {
+        var map = sampleMap();
+
+        Map<ArtifactCoords, List<ArtifactCoords>> decoded = CpeArtifactsEncoder.decode(CpeArtifactsEncoder.encode(map));
+
+        assertThat(decoded).containsOnlyKeys(map.keySet().toArray(ArtifactCoords[]::new));
+        for (var entry : map.entrySet()) {
+            assertThat(decoded.get(entry.getKey())).containsExactlyInAnyOrderElementsOf(entry.getValue());
+        }
+    }
+
+    @Test
+    void entriesAreOrderedByRuntimeKey() {
+        Map<ArtifactCoords, List<ArtifactCoords>> decoded = CpeArtifactsEncoder.decode(CpeArtifactsEncoder.encode(sampleMap()));
+
+        var keys = List.copyOf(decoded.keySet());
+        for (int i = 1; i < keys.size(); i++) {
+            assertThat(keys.get(i - 1).toGACTVString()).isLessThan(keys.get(i).toGACTVString());
+        }
+    }
+
+    @Test
+    void handlesNonJarAndClassifiedCoordinates() {
+        ArtifactCoords rt = ArtifactCoords.jar("org.acme", "acme-rt", "1.0");
+        ArtifactCoords bom = ArtifactCoords.pom("org.acme", "acme-bom", "1.0");
+        ArtifactCoords classified = ArtifactCoords.of("org.acme", "acme-natives", "linux-x86_64", "jar", "1.0");
+
+        String encoded = CpeArtifactsEncoder.encode(Map.of(rt, List.of(rt, bom, classified)));
+        Map<ArtifactCoords, List<ArtifactCoords>> decoded = CpeArtifactsEncoder.decode(encoded);
+
+        assertThat(decoded.get(rt)).containsExactlyInAnyOrder(rt, bom, classified);
+    }
+
+    @Test
+    void roundTripsSharedArtifactIdPrefixWithinGroup() {
+        // Artifacts of the same project share a common artifactId prefix that is factored out.
+        ArtifactCoords rt = ArtifactCoords.jar("org.apache.camel.quarkus", "camel-quarkus-core", "1.0");
+        ArtifactCoords a = ArtifactCoords.jar("org.apache.camel.quarkus", "camel-quarkus-jackson", "1.0");
+        ArtifactCoords b = ArtifactCoords.of("org.apache.camel.quarkus", "camel-quarkus-support", "linux-x86_64", "jar", "1.0");
+
+        Map<ArtifactCoords, List<ArtifactCoords>> decoded = CpeArtifactsEncoder.decode(
+                CpeArtifactsEncoder.encode(Map.of(rt, List.of(rt, a, b))));
+
+        assertThat(decoded.get(rt)).containsExactlyInAnyOrder(rt, a, b);
+    }
+
+    @Test
+    void roundTripsMultipleVersionsInSameGroup() {
+        ArtifactCoords rt = ArtifactCoords.jar("org.acme", "acme-a", "2.0");
+        ArtifactCoords older = ArtifactCoords.jar("org.acme", "acme-a-legacy", "1.0");
+        ArtifactCoords newer = ArtifactCoords.jar("org.acme", "acme-a-deployment", "2.0");
+
+        Map<ArtifactCoords, List<ArtifactCoords>> decoded = CpeArtifactsEncoder.decode(
+                CpeArtifactsEncoder.encode(Map.of(rt, List.of(rt, older, newer))));
+
+        assertThat(decoded.get(rt)).containsExactlyInAnyOrder(rt, older, newer);
+    }
+
+    @Test
+    void roundTripsSingletonGroup() {
+        ArtifactCoords rt = ArtifactCoords.jar("io.quarkus", "quarkus-core", "3.15.0");
+
+        Map<ArtifactCoords, List<ArtifactCoords>> decoded = CpeArtifactsEncoder.decode(
+                CpeArtifactsEncoder.encode(Map.of(rt, List.of(rt))));
+
+        assertThat(decoded.get(rt)).containsExactly(rt);
+    }
+
+    @Test
+    void roundTripsArtifactIdEqualToGroupPrefix() {
+        // The group prefix equals one of the artifactIds, which serializes as an empty artifact line.
+        ArtifactCoords rt = ArtifactCoords.jar("io.quarkus", "quarkus-core", "1.0");
+        ArtifactCoords deployment = ArtifactCoords.jar("io.quarkus", "quarkus-core-deployment", "1.0");
+
+        Map<ArtifactCoords, List<ArtifactCoords>> decoded = CpeArtifactsEncoder.decode(
+                CpeArtifactsEncoder.encode(Map.of(rt, List.of(rt, deployment))));
+
+        assertThat(decoded.get(rt)).containsExactlyInAnyOrder(rt, deployment);
+    }
+
+    @Test
+    void roundTripsArtifactIdEqualToGroupPrefixWithClassifier() {
+        // Same artifactId as the prefix, but carrying a classifier: the empty remainder still keeps the suffix.
+        ArtifactCoords rt = ArtifactCoords.jar("org.acme", "acme", "1.0");
+        ArtifactCoords classified = ArtifactCoords.of("org.acme", "acme", "linux-x86_64", "jar", "1.0");
+        ArtifactCoords sibling = ArtifactCoords.jar("org.acme", "acme-extra", "1.0");
+
+        Map<ArtifactCoords, List<ArtifactCoords>> decoded = CpeArtifactsEncoder.decode(
+                CpeArtifactsEncoder.encode(Map.of(rt, List.of(rt, classified, sibling))));
+
+        assertThat(decoded.get(rt)).containsExactlyInAnyOrder(rt, classified, sibling);
+    }
+
+    @Test
+    void roundTripsSpreadOutDeltaEncodedIndices() {
+        // A closure that references dictionary entries scattered across many groups exercises delta decoding.
+        ArtifactCoords rt = ArtifactCoords.jar("org.acme", "acme-core", "1.0");
+        var value = new ArrayList<ArtifactCoords>();
+        value.add(rt);
+        for (int i = 0; i < 50; i++) {
+            value.add(ArtifactCoords.jar("org.dep" + i, "lib-" + i, "1." + i));
+        }
+
+        Map<ArtifactCoords, List<ArtifactCoords>> decoded = CpeArtifactsEncoder.decode(
+                CpeArtifactsEncoder.encode(Map.of(rt, value)));
+
+        assertThat(decoded.get(rt)).containsExactlyInAnyOrderElementsOf(value);
+    }
+
+    @Test
+    void serializesToExpectedGroupedFormat() {
+        ArtifactCoords rt = ArtifactCoords.jar("org.acme", "acme-a", "1.0");
+        ArtifactCoords deployment = ArtifactCoords.jar("org.acme", "acme-a-deployment", "1.0");
+        ArtifactCoords shared = ArtifactCoords.jar("org.shared", "shared", "2.0");
+
+        String serialized = CpeArtifactsEncoder.serialize(Map.of(rt, List.of(rt, deployment, shared)));
+
+        assertThat(serialized).isEqualTo(""
+                + "@org.acme\n"
+                + "acme-a\n" // group prefix (LCP of acme-a and acme-a-deployment)
+                + "=1.0\n"
+                + "\n" // acme-a: remainder equals the prefix
+                + "-deployment\n" // acme-a-deployment
+                + "@org.shared\n"
+                + "shared\n" // group prefix (single artifact)
+                + "=2.0\n"
+                + "\n" // shared: remainder equals the prefix
+                + "--\n"
+                + "0[0,1,1]\n"); // key index 0; deps at indices 0,1,2 delta-encoded
+    }
+
+    @Test
+    void encodingIsDeterministicRegardlessOfInputOrder() {
+        var natural = sampleMap();
+
+        // A copy with entries and dependency lists shuffled, backed by a differently-ordered map.
+        var entries = new ArrayList<>(natural.entrySet());
+        Collections.shuffle(entries, new Random(1));
+        var shuffled = new LinkedHashMap<ArtifactCoords, List<ArtifactCoords>>();
+        for (var e : entries) {
+            var deps = new ArrayList<>(e.getValue());
+            Collections.shuffle(deps, new Random(2));
+            shuffled.put(e.getKey(), deps);
+        }
+
+        assertThat(CpeArtifactsEncoder.encode(shuffled)).isEqualTo(CpeArtifactsEncoder.encode(natural));
+    }
+
+    @Test
+    void encodedStringIsBase64() {
+        ArtifactCoords rt = ArtifactCoords.jar("org.acme", "acme", "1.0");
+        String encoded = CpeArtifactsEncoder.encode(Map.of(rt, List.of(rt)));
+        assertThat(encoded).matches("[A-Za-z0-9+/=]+");
+    }
+
+    @Test
+    void roundTripEmptyMap() {
+        String encoded = CpeArtifactsEncoder.encode(Map.of());
+        Map<ArtifactCoords, List<ArtifactCoords>> decoded = CpeArtifactsEncoder.decode(encoded);
+        assertThat(decoded).isEmpty();
+    }
+
+    @Test
+    void decodesEmptyStringToEmptyMap() {
+        assertThat(CpeArtifactsEncoder.decode("")).isEmpty();
+    }
+
+    private static Map<ArtifactCoords, List<ArtifactCoords>> sampleMap() {
+        // Each entry is keyed by a runtime artifact whose deployment closure (the value) contains it,
+        // with some dependencies shared across entries to exercise the dictionary.
+        ArtifactCoords rtA = ArtifactCoords.jar("org.acme", "acme-a", "1.0");
+        ArtifactCoords rtB = ArtifactCoords.jar("org.acme", "acme-b", "1.0");
+        ArtifactCoords rtC = ArtifactCoords.jar("org.acme", "acme-c", "1.0");
+        ArtifactCoords shared1 = ArtifactCoords.jar("org.shared", "shared-1", "2.0");
+        ArtifactCoords shared2 = ArtifactCoords.jar("org.shared", "shared-2", "2.0");
+        ArtifactCoords onlyA = ArtifactCoords.jar("org.acme", "acme-a-deployment", "1.0");
+        ArtifactCoords onlyB = ArtifactCoords.jar("org.acme", "acme-b-deployment", "1.0");
+
+        var map = new LinkedHashMap<ArtifactCoords, List<ArtifactCoords>>();
+        map.put(rtA, List.of(rtA, onlyA, shared1, shared2));
+        map.put(rtB, List.of(rtB, onlyB, shared1, shared2));
+        map.put(rtC, List.of(rtC, shared1));
+        return map;
+    }
+}

--- a/platform-bom/src/main/java/io/quarkus/bom/platform/SbomConfig.java
+++ b/platform-bom/src/main/java/io/quarkus/bom/platform/SbomConfig.java
@@ -104,10 +104,11 @@ public class SbomConfig {
         private String stream;
         private String group;
         private String name;
-        private String type = "FRAMEWORK";
+        private String type;
         private String version;
         private String purl;
         private String cpe;
+        private String offering;
         private String description;
         private ReleaseNotes releaseNotes;
 
@@ -193,6 +194,14 @@ public class SbomConfig {
 
         public void setCpe(String cpe) {
             this.cpe = cpe;
+        }
+
+        public String getOffering() {
+            return offering;
+        }
+
+        public void setOffering(String offering) {
+            this.offering = offering;
         }
 
         /**


### PR DESCRIPTION
Allows passing product CPE and extension support data as Quarkus platform properties to application builds.